### PR TITLE
Modelo y CLI inicial de base de datos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+ENV=dev
+DB_URL_POSTGRES=postgresql+psycopg://user:pass@localhost:5432/growen
+DB_URL_SQLITE=sqlite:///./growen.db
+USE_SQLITE=1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Growen
+
+Agente modular para cultivo y e-commerce.
+
+## Configuración de Base de Datos
+
+1. Crea un archivo `.env` basado en `.env.example` y ajusta las credenciales.
+2. Instala las dependencias del proyecto:
+   ```bash
+   pip install -e .[dev]
+   ```
+3. Ejecuta las migraciones para crear las tablas:
+   ```bash
+   python -m cli.ng db init
+   ```
+4. Verifica la cantidad de registros:
+   ```bash
+   python -m cli.ng db info
+   ```
+5. Exporta el catálogo a CSV:
+   ```bash
+   python -m cli.ng catalog export --out catalogo.csv
+   ```
+6. Corre los tests:
+   ```bash
+   pytest
+   ```

--- a/agent_core/__init__.py
+++ b/agent_core/__init__.py
@@ -1,0 +1,5 @@
+"""Módulo central del agente."""
+
+from .settings import Settings
+
+settings = Settings()

--- a/agent_core/db.py
+++ b/agent_core/db.py
@@ -1,0 +1,26 @@
+"""Conexión y utilidades de base de datos."""
+
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+from .settings import settings
+
+engine = create_engine(settings.db_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base = declarative_base()
+
+
+@contextmanager
+def get_session():
+    """Provee una sesión de base de datos en un contexto administrado."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/agent_core/models.py
+++ b/agent_core/models.py
@@ -1,0 +1,174 @@
+"""Modelos de datos principales."""
+
+from decimal import Decimal
+import enum
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    Index,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .db import Base
+
+
+class StatusEnum(str, enum.Enum):
+    active = "active"
+    draft = "draft"
+    archived = "archived"
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    parent_id = Column(ForeignKey("categories.id"))
+
+    parent = relationship("Category", remote_side=[id])
+    products = relationship("Product", back_populates="category")
+
+    __table_args__ = (Index("ix_categories_parent_id", "parent_id"),)
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id = Column(Integer, primary_key=True)
+    sku_root = Column(String, unique=True)
+    title = Column(String, nullable=False)
+    brand = Column(String)
+    category_id = Column(ForeignKey("categories.id"))
+    description_html = Column(Text)
+    slug = Column(String, nullable=False, unique=True)
+    status = Column(Enum(StatusEnum), nullable=False, default=StatusEnum.active)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    category = relationship("Category", back_populates="products")
+    variants = relationship("Variant", back_populates="product", cascade="all, delete-orphan")
+    images = relationship("Image", back_populates="product", cascade="all, delete-orphan")
+    tags = relationship("Tag", secondary="product_tags", back_populates="products")
+
+    __table_args__ = (
+        Index("ix_products_slug", "slug", unique=True),
+        Index("ix_products_category_id", "category_id"),
+    )
+
+
+class Variant(Base):
+    __tablename__ = "variants"
+
+    id = Column(Integer, primary_key=True)
+    product_id = Column(ForeignKey("products.id", ondelete="CASCADE"), nullable=False)
+    sku = Column(String, nullable=False, unique=True)
+    name = Column(String)
+    value = Column(String)
+    barcode = Column(String)
+    price = Column(Numeric(12, 2), nullable=False)
+    promo_price = Column(Numeric(12, 2))
+    weight_kg = Column(Numeric(10, 3))
+    length_cm = Column(Numeric(10, 2))
+    width_cm = Column(Numeric(10, 2))
+    height_cm = Column(Numeric(10, 2))
+    status = Column(Enum(StatusEnum), nullable=False, default=StatusEnum.active)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    product = relationship("Product", back_populates="variants")
+    inventory = relationship("Inventory", back_populates="variant", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        Index("ix_variants_sku", "sku", unique=True),
+        Index("ix_variants_product_id_status", "product_id", "status"),
+    )
+
+
+class Inventory(Base):
+    __tablename__ = "inventory"
+
+    id = Column(Integer, primary_key=True)
+    variant_id = Column(ForeignKey("variants.id"), nullable=False)
+    warehouse = Column(String, nullable=False, default="default")
+    stock_qty = Column(Integer, nullable=False, default=0)
+
+    variant = relationship("Variant", back_populates="inventory")
+
+    __table_args__ = (
+        UniqueConstraint("variant_id", "warehouse", name="uq_inventory_variant_warehouse"),
+    )
+
+
+class Image(Base):
+    __tablename__ = "images"
+
+    id = Column(Integer, primary_key=True)
+    product_id = Column(ForeignKey("products.id", ondelete="CASCADE"), nullable=False)
+    url = Column(String, nullable=False)
+    alt = Column(String)
+    sort_order = Column(Integer, default=0)
+
+    product = relationship("Product", back_populates="images")
+
+
+class Tag(Base):
+    __tablename__ = "tags"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False, unique=True)
+
+    products = relationship("Product", secondary="product_tags", back_populates="tags")
+
+
+class ProductTag(Base):
+    __tablename__ = "product_tags"
+
+    product_id = Column(ForeignKey("products.id", ondelete="CASCADE"), primary_key=True)
+    tag_id = Column(ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True)
+
+    __table_args__ = (
+        UniqueConstraint("product_id", "tag_id", name="uq_product_tag"),
+    )
+
+
+class PriceList(Base):
+    __tablename__ = "price_lists"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False, unique=True)
+
+    prices = relationship("VariantPrice", back_populates="price_list", cascade="all, delete-orphan")
+
+
+class VariantPrice(Base):
+    __tablename__ = "variant_prices"
+
+    variant_id = Column(ForeignKey("variants.id", ondelete="CASCADE"), primary_key=True)
+    price_list_id = Column(ForeignKey("price_lists.id", ondelete="CASCADE"), primary_key=True)
+    price = Column(Numeric(12, 2), nullable=False)
+
+    variant = relationship("Variant")
+    price_list = relationship("PriceList", back_populates="prices")
+
+    __table_args__ = (
+        UniqueConstraint("variant_id", "price_list_id", name="uq_variant_price"),
+    )

--- a/agent_core/settings.py
+++ b/agent_core/settings.py
@@ -1,0 +1,37 @@
+import os
+
+try:
+    from pydantic_settings import BaseSettings, SettingsConfigDict
+
+    class Settings(BaseSettings):
+        """Configuración basada en Pydantic."""
+
+        env: str = "dev"
+        db_url_postgres: str = "postgresql+psycopg://user:pass@localhost:5432/growen"
+        db_url_sqlite: str = "sqlite:///./growen.db"
+        use_sqlite: bool = True
+
+        model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)
+
+        @property
+        def db_url(self) -> str:
+            return self.db_url_sqlite if self.use_sqlite else self.db_url_postgres
+
+except ModuleNotFoundError:
+    class Settings:
+        """Fallback simple cuando Pydantic no está disponible."""
+
+        def __init__(self) -> None:
+            self.env = os.getenv("ENV", "dev")
+            self.db_url_postgres = os.getenv(
+                "DB_URL_POSTGRES", "postgresql+psycopg://user:pass@localhost:5432/growen"
+            )
+            self.db_url_sqlite = os.getenv("DB_URL_SQLITE", "sqlite:///./growen.db")
+            self.use_sqlite = os.getenv("USE_SQLITE", "1") == "1"
+
+        @property
+        def db_url(self) -> str:
+            return self.db_url_sqlite if self.use_sqlite else self.db_url_postgres
+
+
+settings = Settings()

--- a/cli/ng.py
+++ b/cli/ng.py
@@ -1,0 +1,116 @@
+"""CLI principal del proyecto."""
+
+import csv
+from pathlib import Path
+
+import typer
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import select, func
+
+from agent_core import settings
+from agent_core.db import Base, engine, get_session
+from agent_core.models import Product, Variant, Inventory, Image
+
+app = typer.Typer()
+
+
+def get_alembic_config() -> Config:
+    """Obtiene la configuración de Alembic."""
+    cfg = Config(str(Path(__file__).resolve().parent.parent / "infra" / "alembic.ini"))
+    return cfg
+
+
+@app.command()
+def version() -> None:
+    """Muestra la versión de la aplicación."""
+    typer.echo("Growen CLI")
+
+
+db_app = typer.Typer(help="Comandos relacionados con la base de datos")
+app.add_typer(db_app, name="db")
+
+
+@db_app.command("init")
+def db_init() -> None:
+    """Ejecuta migraciones para inicializar la base de datos."""
+    cfg = get_alembic_config()
+    command.upgrade(cfg, "head")
+    typer.echo("Migraciones aplicadas")
+
+
+@db_app.command("drop")
+def db_drop(force: bool = typer.Option(False, "--force", help="Omitir confirmación")) -> None:
+    """Elimina todas las tablas (solo modo dev)."""
+    if settings.env != "dev":
+        typer.echo("Operación permitida solo en entorno de desarrollo")
+        raise typer.Exit(1)
+    if force or typer.confirm("¿Seguro que quieres eliminar todas las tablas?"):
+        Base.metadata.drop_all(bind=engine)
+        typer.echo("Tablas eliminadas")
+
+
+@db_app.command("info")
+def db_info() -> None:
+    """Muestra la cantidad de registros por tabla."""
+    with get_session() as session:
+        products = session.scalar(select(func.count(Product.id))) or 0
+        variants = session.scalar(select(func.count(Variant.id))) or 0
+        images = session.scalar(select(func.count(Image.id))) or 0
+        inventory = session.scalar(select(func.count(Inventory.id))) or 0
+    typer.echo(f"products: {products}")
+    typer.echo(f"variants: {variants}")
+    typer.echo(f"images: {images}")
+    typer.echo(f"inventory: {inventory}")
+
+
+catalog_app = typer.Typer(help="Operaciones con el catálogo")
+app.add_typer(catalog_app, name="catalog")
+
+
+@catalog_app.command("export")
+def catalog_export(out: Path = typer.Option(..., "--out", help="Archivo CSV de salida")) -> None:
+    """Exporta productos con variantes e inventario a CSV."""
+    with get_session() as session:
+        img_subq = (
+            select(Image.url)
+            .where(Image.product_id == Product.id)
+            .order_by(Image.sort_order)
+            .limit(1)
+            .scalar_subquery()
+        )
+
+        query = (
+            select(
+                Product.id,
+                Product.slug,
+                Product.title,
+                Variant.sku,
+                Variant.price,
+                Inventory.stock_qty,
+                img_subq.label("image_url"),
+            )
+            .join(Variant, Variant.product_id == Product.id)
+            .join(Inventory, Inventory.variant_id == Variant.id, isouter=True)
+        )
+
+        with out.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(
+                [
+                    "product_id",
+                    "product_slug",
+                    "product_title",
+                    "variant_sku",
+                    "variant_price",
+                    "stock_qty",
+                    "image_url",
+                ]
+            )
+            for row in session.execute(query):
+                writer.writerow(row)
+    typer.echo(f"Catálogo exportado a {out}")
+
+
+if __name__ == "__main__":
+    app()

--- a/infra/alembic.ini
+++ b/infra/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = infra/alembic
+sqlalchemy.url = sqlite:///./growen.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(name)s %(message)s

--- a/infra/alembic/env.py
+++ b/infra/alembic/env.py
@@ -1,0 +1,41 @@
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from agent_core.db import Base
+from agent_core.settings import settings
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+config.set_main_option("sqlalchemy.url", settings.db_url)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=settings.db_url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/infra/alembic/versions/0001_initial.py
+++ b/infra/alembic/versions/0001_initial.py
@@ -1,0 +1,132 @@
+"""initial schema"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+status_enum = sa.Enum("active", "draft", "archived", name="statusenum")
+
+
+def upgrade() -> None:
+    status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "categories",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("parent_id", sa.Integer(), sa.ForeignKey("categories.id")),
+    )
+    op.create_index("ix_categories_parent_id", "categories", ["parent_id"], unique=False)
+
+    op.create_table(
+        "products",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("sku_root", sa.String(), unique=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("brand", sa.String()),
+        sa.Column("category_id", sa.Integer(), sa.ForeignKey("categories.id")),
+        sa.Column("description_html", sa.Text()),
+        sa.Column("slug", sa.String(), nullable=False, unique=True),
+        sa.Column("status", status_enum, nullable=False, server_default="active"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_products_slug", "products", ["slug"], unique=True)
+    op.create_index("ix_products_category_id", "products", ["category_id"], unique=False)
+
+    op.create_table(
+        "tags",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False, unique=True),
+    )
+
+    op.create_table(
+        "price_lists",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False, unique=True),
+    )
+
+    op.create_table(
+        "variants",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("product_id", sa.Integer(), sa.ForeignKey("products.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("sku", sa.String(), nullable=False, unique=True),
+        sa.Column("name", sa.String()),
+        sa.Column("value", sa.String()),
+        sa.Column("barcode", sa.String()),
+        sa.Column("price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("promo_price", sa.Numeric(12, 2)),
+        sa.Column("weight_kg", sa.Numeric(10, 3)),
+        sa.Column("length_cm", sa.Numeric(10, 2)),
+        sa.Column("width_cm", sa.Numeric(10, 2)),
+        sa.Column("height_cm", sa.Numeric(10, 2)),
+        sa.Column("status", status_enum, nullable=False, server_default="active"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_variants_sku", "variants", ["sku"], unique=True)
+    op.create_index("ix_variants_product_id_status", "variants", ["product_id", "status"], unique=False)
+
+    op.create_table(
+        "images",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("product_id", sa.Integer(), sa.ForeignKey("products.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("alt", sa.String()),
+        sa.Column("sort_order", sa.Integer(), server_default="0"),
+    )
+
+    op.create_table(
+        "inventory",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("variant_id", sa.Integer(), sa.ForeignKey("variants.id"), nullable=False),
+        sa.Column("warehouse", sa.String(), nullable=False, server_default="default"),
+        sa.Column("stock_qty", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_unique_constraint("uq_inventory_variant_warehouse", "inventory", ["variant_id", "warehouse"])
+
+    op.create_table(
+        "product_tags",
+        sa.Column("product_id", sa.Integer(), sa.ForeignKey("products.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("tag_id", sa.Integer(), sa.ForeignKey("tags.id", ondelete="CASCADE"), primary_key=True),
+    )
+    op.create_unique_constraint("uq_product_tag", "product_tags", ["product_id", "tag_id"])
+
+    op.create_table(
+        "variant_prices",
+        sa.Column("variant_id", sa.Integer(), sa.ForeignKey("variants.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("price_list_id", sa.Integer(), sa.ForeignKey("price_lists.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("price", sa.Numeric(12, 2), nullable=False),
+    )
+    op.create_unique_constraint("uq_variant_price", "variant_prices", ["variant_id", "price_list_id"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_variant_price", "variant_prices", type_="unique")
+    op.drop_table("variant_prices")
+    op.drop_table("price_lists")
+
+    op.drop_table("product_tags")
+    op.drop_table("tags")
+
+    op.drop_constraint("uq_inventory_variant_warehouse", "inventory", type_="unique")
+    op.drop_table("inventory")
+
+    op.drop_table("images")
+    op.drop_index("ix_variants_product_id_status", table_name="variants")
+    op.drop_index("ix_variants_sku", table_name="variants")
+    op.drop_table("variants")
+
+    op.drop_index("ix_products_category_id", table_name="products")
+    op.drop_index("ix_products_slug", table_name="products")
+    op.drop_table("products")
+
+    op.drop_index("ix_categories_parent_id", table_name="categories")
+    op.drop_table("categories")
+
+    status_enum.drop(op.get_bind(), checkfirst=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nicegrow-agent"
+version = "0.1.0"
+description = "Agente modular para cultivo y e-commerce"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name = "Growen", email = ""}]
+dependencies = [
+    "SQLAlchemy>=2.0",
+    "alembic>=1.9",
+    "pydantic>=2.0",
+    "pydantic-settings>=2.0",
+    "typer>=0.9",
+    "python-dotenv>=1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "coverage",
+    "factory_boy",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("USE_SQLITE", "1")
+os.environ.setdefault("DB_URL_SQLITE", "sqlite:///:memory:")
+
+# Añade el directorio raíz del proyecto al path para importar los módulos sin instalar
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from agent_core.db import Base, engine, SessionLocal
+
+
+@pytest.fixture
+def session():
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,19 @@
+from decimal import Decimal
+
+from agent_core.models import Product, Variant, Image, Inventory
+
+
+def test_create_product_with_relations(session):
+    product = Product(title="Prod", slug="prod")
+    variant1 = Variant(sku="SKU1", price=Decimal("10.00"), product=product)
+    variant2 = Variant(sku="SKU2", price=Decimal("20.00"), product=product)
+    Image(url="http://example.com/img.jpg", product=product)
+    Inventory(variant=variant1, stock_qty=5)
+
+    session.add(product)
+    session.commit()
+
+    assert session.query(Product).count() == 1
+    assert session.query(Variant).count() == 2
+    assert session.query(Image).count() == 1
+    assert session.query(Inventory).filter_by(variant_id=variant1.id).one().stock_qty == 5


### PR DESCRIPTION
## Resumen
- Configuración de entorno y selección automática de base de datos
- Modelos SQLAlchemy para catálogo, inventario y precios
- CLI con comandos para migraciones, información y exportación de catálogo

## Testing
- `pip install -e .[dev]` *(falló: Could not find a version that satisfies the requirement setuptools)*
- `python -m cli.ng db info` *(falló: ModuleNotFoundError: No module named 'typer')*
- `pytest` *(falló: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689e2b1554d48330a2800e46f99cfda0