### PR TITLE
feat: configurar PostgreSQL y documentar despliegue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # Runtime
 ENV=dev
-DB_URL=sqlite+aiosqlite:///./growen.db
-PG_URL=postgresql+psycopg://user:pass@localhost:5432/growen
+DB_URL=postgresql+psycopg://usuario:clave@localhost:5432/growen
 
 # Tiendanube
 TN_CLIENT_ID=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY pyproject.toml README.md ./
+RUN pip install --upgrade pip && pip install .
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "services.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -2,37 +2,114 @@
 
 Agente modular para cultivo y e-commerce.
 
-## Configuración de Base de Datos
+## Configuración de Base de Datos con PostgreSQL
 
-1. Crea un archivo `.env` basado en `.env.example` y ajusta las credenciales.
-2. Instala las dependencias del proyecto:
+1. Crea un archivo `.env` basado en `.env.example` y ajusta `DB_URL` con las credenciales de tu servidor PostgreSQL. El formato esperado es:
+   ```env
+   DB_URL=postgresql+psycopg://usuario:clave@localhost:5432/growen
+   ```
+2. Si no tienes PostgreSQL instalado, puedes levantarlo rápidamente con Docker:
+   ```bash
+   docker run -d --name growen-db -p 5432:5432 \
+     -e POSTGRES_USER=usuario -e POSTGRES_PASSWORD=clave \
+     -e POSTGRES_DB=growen postgres:15
+   ```
+3. Antes del primer uso asegúrate de que exista la base `growen`. Puedes crearla manualmente con `CREATE DATABASE growen;` o dejar que Alembic la cree si el usuario tiene permisos.
+4. Instala las dependencias del proyecto:
    ```bash
    pip install -e .[dev]
    ```
-3. Ejecuta las migraciones para crear las tablas:
+5. Ejecuta las migraciones para crear las tablas en PostgreSQL:
    ```bash
    python -m cli.ng db init
    ```
-4. Verifica la cantidad de registros:
+6. Verifica la cantidad de registros:
    ```bash
    python -m cli.ng db info
    ```
-5. Exporta el catálogo a CSV:
+7. Exporta el catálogo a CSV:
    ```bash
    python -m cli.ng catalog export --out catalogo.csv
    ```
-6. Corre los tests:
+8. Corre los tests (se usa una base SQLite en memoria):
    ```bash
    pytest
    ```
 
+## Variables de entorno
+
+- `ENV`: entorno de ejecución (`dev` o `prod`). Con `ENV=prod` se deshabilitan operaciones peligrosas como el borrado de tablas.
+- `DB_URL`: URL de conexión a PostgreSQL en formato `postgresql+psycopg://usuario:clave@host:5432/base`.
+- `TN_CLIENT_ID`, `TN_CLIENT_SECRET`, `TN_ACCESS_TOKEN`, `TN_SHOP_ID`: credenciales de la API de Tiendanube.
+- `AI_MODE`: modo de IA (`auto`, `openai` u `ollama`).
+- `OLLAMA_HOST`, `OLLAMA_MODEL`: configuración del modelo local.
+- `OPENAI_API_KEY`, `OPENAI_MODEL`: configuración para OpenAI.
+- `AI_ALLOW_EXTERNAL`: si es `false`, obliga a usar solo el modelo local.
+
 ## Ejecución del servicio API
 
-1. Inicia el backend de desarrollo:
-   ```bash
-   uvicorn services.api:app --reload
-   ```
-2. Revisa la salud del servicio visitando `http://localhost:8000/health`.
+### Desarrollo
+
+```bash
+uvicorn services.api:app --reload
+```
+
+### Producción
+
+```bash
+ENV=prod uvicorn services.api:app --host 0.0.0.0 --port 8000
+```
+Se recomienda ejecutarlo sin `--reload` y detrás de un proxy web.
+
+Revisa la salud del servicio visitando `http://localhost:8000/health`.
+
+## Integración con Tiendanube
+
+El agente está diseñado para sincronizar el catálogo con una tienda de Tiendanube utilizando las credenciales `TN_*`.
+
+Comandos disponibles:
+
+- `/sync pull --dry-run`: obtener el catálogo sin aplicar cambios.
+- `/sync pull --apply`: importar productos y actualizarlos localmente.
+- `/sync push --dry-run`: simular el envío de cambios locales.
+- `/sync push --apply`: aplicar en Tiendanube los cambios de la base local.
+- `/stock adjust --sku=<SKU> --qty=<N>`: ajustar stock localmente para luego sincronizarlo.
+
+Estas acciones se exponen vía API en `/actions` y pueden ejecutarse desde la interfaz de chat o vía HTTP.
+
+## Población inicial de datos
+
+Tras correr las migraciones, la base de datos queda vacía. Puedes:
+
+- Ejecutar `/sync pull --apply` (cuando esté implementado) para importar el catálogo de Tiendanube.
+- Insertar registros de prueba manualmente para explorar los endpoints.
+
+## Objetivos del proyecto
+
+- **E-commerce**: almacenar el catálogo de productos y sincronizarlo con la tienda.
+- **IA**: combinar Ollama y OpenAI para interpretar comandos y generar contenido.
+- **Cultivo**: la arquitectura es modular para integrar sensores y tareas agrícolas en el futuro.
+
+## Uso con Docker (opcional)
+
+### Construcción de la imagen
+
+```bash
+docker build -t growen:latest .
+```
+
+### Ejecución del contenedor
+
+```bash
+docker run --env-file .env -p 8000:8000 growen:latest
+```
+
+### Docker Compose (desarrollo)
+
+```bash
+docker-compose up --build
+```
+Inicia la API en `localhost:8000` y PostgreSQL en el puerto `5432`.
 
 ## Modo de IA híbrido
 
@@ -40,8 +117,6 @@ El proyecto integra dos proveedores de lenguaje:
 
 - **Ollama** (local) para NLU y respuestas cortas.
 - **OpenAI** para generación de contenido largo y tareas de SEO.
-
-Configura las variables del archivo `.env` siguiendo `.env.example`.
 
 ### Instalación de Ollama
 

--- a/agent_core/settings.py
+++ b/agent_core/settings.py
@@ -7,8 +7,7 @@ try:
         """Configuración basada en Pydantic para todo el proyecto."""
 
         env: str = "dev"
-        db_url: str = "sqlite+aiosqlite:///./growen.db"
-        pg_url: str = "postgresql+psycopg://user:pass@localhost:5432/growen"
+        db_url: str = "postgresql+psycopg://user:pass@localhost:5432/growen"
         tn_client_id: str | None = None
         tn_client_secret: str | None = None
         tn_access_token: str | None = None
@@ -23,9 +22,8 @@ except ModuleNotFoundError:
 
         def __init__(self) -> None:
             self.env = os.getenv("ENV", "dev")
-            self.db_url = os.getenv("DB_URL", "sqlite+aiosqlite:///./growen.db")
-            self.pg_url = os.getenv(
-                "PG_URL", "postgresql+psycopg://user:pass@localhost:5432/growen"
+            self.db_url = os.getenv(
+                "DB_URL", "postgresql+psycopg://user:pass@localhost:5432/growen"
             )
             self.tn_client_id = os.getenv("TN_CLIENT_ID")
             self.tn_client_secret = os.getenv("TN_CLIENT_SECRET")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: usuario
+      POSTGRES_PASSWORD: clave
+      POSTGRES_DB: growen
+    ports:
+      - "5432:5432"
+  app:
+    build: .
+    depends_on:
+      - db
+    env_file: .env
+    environment:
+      DB_URL: postgresql+psycopg://usuario:clave@db:5432/growen
+    ports:
+      - "8000:8000"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.11"
 authors = [{name = "Growen", email = ""}]
 dependencies = [
     "SQLAlchemy>=2.0",
+    "psycopg[binary]>=3.1",
     "alembic>=1.9",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ import os
 import sys
 from pathlib import Path
 
-os.environ.setdefault("USE_SQLITE", "1")
-os.environ.setdefault("DB_URL_SQLITE", "sqlite:///:memory:")
+# Usa una base SQLite en memoria para los tests sin afectar PostgreSQL.
+os.environ.setdefault("DB_URL", "sqlite:///:memory:")
 
 # Añade el directorio raíz del proyecto al path para importar los módulos sin instalar
 sys.path.append(str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Resumen
- reemplazo de SQLite por PostgreSQL como base predeterminada
- documentación ampliada para configuraciones, entorno y Docker
- ajustes en pruebas para usar SQLite en memoria

## Testing
- `pip install -e .[dev]` *(falla: Could not find a version that satisfies the requirement setuptools)*
- `pytest` *(falla: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689e39410170833098ea2763df282bce