### PR TITLE
feat: ingest Santa Planta and track supplier prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,26 @@ Con `--dry-run` se generan reportes en `data/reports/` sin tocar la base. Al apl
 
 Si el archivo no incluye SKU ni GTIN se genera uno interno estable. Las categorías y marcas se crean si no existen y los productos quedan en estado `draft` por defecto.
 
+### Ingesta Santa Planta (mensual)
+
+1. En el chat adjuntá el Excel `ListaPrecios_export_XXXX.xlsx`.
+2. Growen detecta automáticamente el proveedor y ejecuta un *dry-run*.
+3. Revisá los reportes generados en `data/reports/`.
+4. Para aplicar los cambios ejecutá `/import last --apply` en el chat o:
+
+```bash
+python -m cli.ng ingest file ListaPrecios_export_XXXX.xlsx --supplier santa-planta --dry-run
+python -m cli.ng ingest last --apply
+```
+
+### Historial de precios
+
+Cada ingestión registra los precios de compra y venta en la tabla `supplier_price_history` con las variaciones porcentuales respecto del último valor conocido.
+
+### Stock
+
+El catálogo base ingresa con `stock_qty=0` en `inventory`. La sincronización de stock con proveedores se agregará más adelante.
+
 ## IA híbrida
 
 La política por defecto utiliza:

--- a/alembic/versions/add_suppliers_price_history.py
+++ b/alembic/versions/add_suppliers_price_history.py
@@ -1,0 +1,67 @@
+"""add suppliers and price history tables"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import table, column
+
+# revision identifiers, used by Alembic.
+revision = 'add_suppliers_price_history'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'suppliers',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('slug', sa.String(50), unique=True),
+        sa.Column('name', sa.String(100)),
+        sa.Column('created_at', sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+    op.create_table(
+        'supplier_files',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('supplier_id', sa.Integer, sa.ForeignKey('suppliers.id')),
+        sa.Column('filename', sa.String(200)),
+        sa.Column('sha256', sa.String(64)),
+        sa.Column('rows', sa.Integer),
+        sa.Column('uploaded_at', sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column('processed', sa.Boolean, default=False),
+        sa.Column('dry_run', sa.Boolean, default=True),
+        sa.Column('notes', sa.Text),
+    )
+    op.create_table(
+        'supplier_products',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('supplier_id', sa.Integer, sa.ForeignKey('suppliers.id')),
+        sa.Column('supplier_product_id', sa.String(100)),
+        sa.Column('title', sa.String(200)),
+        sa.Column('category_level_1', sa.String(100)),
+        sa.Column('category_level_2', sa.String(100)),
+        sa.Column('category_level_3', sa.String(100)),
+        sa.Column('min_purchase_qty', sa.Numeric(10,2)),
+        sa.Column('current_purchase_price', sa.Numeric(10,2)),
+        sa.Column('current_sale_price', sa.Numeric(10,2)),
+        sa.Column('last_seen_at', sa.DateTime),
+        sa.Column('internal_product_id', sa.Integer, sa.ForeignKey('products.id')),
+        sa.Column('internal_variant_id', sa.Integer, sa.ForeignKey('variants.id')),
+        sa.UniqueConstraint('supplier_id', 'supplier_product_id'),
+    )
+    op.create_table(
+        'supplier_price_history',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('supplier_product_fk', sa.Integer, sa.ForeignKey('supplier_products.id')),
+        sa.Column('file_fk', sa.Integer, sa.ForeignKey('supplier_files.id')),
+        sa.Column('as_of_date', sa.Date),
+        sa.Column('purchase_price', sa.Numeric(10,2)),
+        sa.Column('sale_price', sa.Numeric(10,2)),
+        sa.Column('delta_purchase_pct', sa.Numeric(10,2)),
+        sa.Column('delta_sale_pct', sa.Numeric(10,2)),
+        sa.Column('created_at', sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('supplier_price_history')
+    op.drop_table('supplier_products')
+    op.drop_table('supplier_files')
+    op.drop_table('suppliers')

--- a/config/suppliers/santa-planta.yml
+++ b/config/suppliers/santa-planta.yml
@@ -1,0 +1,25 @@
+supplier_name: "Santa Planta"
+slug: "santa-planta"
+file_type: "xlsx"
+sheet_name: "data"
+header_row: 1
+columns:
+  supplier_product_id: ["ID"]
+  title: ["Producto"]
+  category_level_1: ["Agrupamiento"]
+  category_level_2: ["Familia"]
+  category_level_3: ["SubFamilia"]
+  min_purchase_qty: ["Compra Minima"]
+  supplier_stock: ["Stock"]
+  purchase_price: ["PrecioDeCompra"]
+  sale_price: ["PrecioDeVenta"]
+transform:
+  purchase_price:
+    replace_comma_decimal: false
+  sale_price:
+    replace_comma_decimal: false
+defaults:
+  status: "draft"
+  stock_qty: 0
+  min_qty: 0
+category_map: {}

--- a/services/ingest/detect.py
+++ b/services/ingest/detect.py
@@ -4,14 +4,35 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+import pandas as pd
 import yaml
 
 
 def detect_supplier(path: str | Path) -> Optional[str]:
-    """Intenta adivinar el proveedor según el encabezado."""
+    """Intenta adivinar el proveedor según archivo y cabeceras."""
     path = Path(path)
     if path.suffix.lower() not in {".csv", ".xlsx"}:
         return None
+    # detección específica para Santa Planta
+    if "listaprecios_export" in path.name.lower():
+        try:
+            df = pd.read_excel(path, sheet_name="data", header=0)
+        except Exception:
+            return None
+        expected = {
+            "ID",
+            "Agrupamiento",
+            "Familia",
+            "SubFamilia",
+            "Producto",
+            "Compra Minima",
+            "Stock",
+            "PrecioDeCompra",
+            "PrecioDeVenta",
+        }
+        if expected.issubset(set(df.columns)):
+            return "santa-planta"
+    # fallback: detectar por extensión
     config_dir = Path("config/suppliers")
     for yml in config_dir.glob("*.yml"):
         with open(yml, "r", encoding="utf-8") as f:

--- a/services/ingest/mapping.py
+++ b/services/ingest/mapping.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import pandas as pd
 
 
-REQUIRED_FIELDS = {"title", "price"}
+REQUIRED_FIELDS = {"supplier_product_id", "title"}
 
 
 def map_columns(df: pd.DataFrame, mapping: Dict[str, Any]) -> pd.DataFrame:

--- a/services/ingest/upsert.py
+++ b/services/ingest/upsert.py
@@ -2,12 +2,21 @@
 from __future__ import annotations
 
 import hashlib
+from datetime import date, datetime
 from typing import Any, Iterable
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from db.models import Inventory, Product, Variant
+from db.models import (
+    Inventory,
+    Product,
+    Variant,
+    Supplier,
+    SupplierFile,
+    SupplierPriceHistory,
+    SupplierProduct,
+)
 
 
 async def upsert_rows(
@@ -59,3 +68,111 @@ def _generate_sku(row: dict[str, Any], supplier_name: str) -> str:
         return f"EAN-{barcode}".upper()
     base = f"{supplier_name}-{row.get('title','')}-{row.get('variant_value','')}"
     return "SUP-" + hashlib.sha1(base.encode()).hexdigest()[:8].upper()
+
+
+async def upsert_supplier_rows(
+    rows: Iterable[dict[str, Any]],
+    session: AsyncSession,
+    supplier_slug: str,
+    dry_run: bool = True,
+) -> dict[str, int]:
+    """Upsert específico para proveedores con historial de precios."""
+    created = 0
+    updated = 0
+    supplier = await session.scalar(select(Supplier).where(Supplier.slug == supplier_slug))
+    if not supplier:
+        supplier = Supplier(slug=supplier_slug, name="Santa Planta")
+        session.add(supplier)
+        await session.flush()
+    rows_list = list(rows)
+    file_rec = SupplierFile(
+        supplier_id=supplier.id,
+        filename="upload.xlsx",
+        sha256="",
+        rows=len(rows_list),
+        processed=not dry_run,
+        dry_run=dry_run,
+    )
+    session.add(file_rec)
+    await session.flush()
+    for row in rows_list:
+        spid = str(row.get("supplier_product_id"))
+        sku = row.get("sku") or "SP-" + hashlib.sha1(spid.encode()).hexdigest()[:8].upper()
+        title = row.get("title", "")
+        purchase_price = row.get("purchase_price")
+        sale_price = row.get("sale_price")
+        stmt = select(SupplierProduct).where(
+            SupplierProduct.supplier_id == supplier.id,
+            SupplierProduct.supplier_product_id == spid,
+        )
+        sup_prod = await session.scalar(stmt)
+        if not sup_prod:
+            sup_prod = SupplierProduct(
+                supplier_id=supplier.id,
+                supplier_product_id=spid,
+                title=title,
+            )
+            session.add(sup_prod)
+            await session.flush()
+            created += 1
+        else:
+            sup_prod.title = title
+            updated += 1
+        sup_prod.category_level_1 = row.get("category_level_1")
+        sup_prod.category_level_2 = row.get("category_level_2")
+        sup_prod.category_level_3 = row.get("category_level_3")
+        sup_prod.min_purchase_qty = row.get("min_purchase_qty")
+        last_purchase = sup_prod.current_purchase_price
+        last_sale = sup_prod.current_sale_price
+        sup_prod.current_purchase_price = purchase_price
+        sup_prod.current_sale_price = sale_price
+        sup_prod.last_seen_at = datetime.utcnow()
+
+        delta_purchase = None
+        delta_sale = None
+        if last_purchase is not None and purchase_price not in (None, 0):
+            if last_purchase != 0:
+                delta_purchase = (purchase_price - last_purchase) / last_purchase * 100
+        if last_sale is not None and sale_price not in (None, 0):
+            if last_sale != 0:
+                delta_sale = (sale_price - last_sale) / last_sale * 100
+        session.add(
+            SupplierPriceHistory(
+                supplier_product_fk=sup_prod.id,
+                file_fk=file_rec.id,
+                as_of_date=date.today(),
+                purchase_price=purchase_price,
+                sale_price=sale_price,
+                delta_purchase_pct=delta_purchase,
+                delta_sale_pct=delta_sale,
+            )
+        )
+
+        # producto interno
+        stmt = select(Variant).where(Variant.sku == sku)
+        variant = await session.scalar(stmt)
+        if not variant:
+            product = Product(sku_root=sku, title=title, status="draft")
+            session.add(product)
+            await session.flush()
+            variant = Variant(product_id=product.id, sku=sku, price=sale_price)
+            session.add(variant)
+            await session.flush()
+            inventory = Inventory(
+                variant_id=variant.id,
+                stock_qty=0,
+                min_qty=row.get("min_qty", 0),
+                warehouse="central",
+            )
+            session.add(inventory)
+        else:
+            if sale_price is not None:
+                variant.price = sale_price
+        sup_prod.internal_product_id = variant.product_id
+        sup_prod.internal_variant_id = variant.id
+
+    if dry_run:
+        await session.rollback()
+    else:
+        await session.commit()
+    return {"created": created, "updated": updated}

--- a/services/ingest/validate.py
+++ b/services/ingest/validate.py
@@ -1,14 +1,16 @@
 """Validaciones simples de filas."""
 from __future__ import annotations
 
-from typing import Dict, Any, Tuple
+from typing import Any, Dict, Tuple
 
 
 def validate_row(row: Dict[str, Any]) -> Tuple[bool, str | None]:
-    """Valida campos mínimos."""
+    """Valida campos mínimos para productos de proveedor."""
+    if not row.get("supplier_product_id"):
+        return False, "supplier_product_id requerido"
     if not row.get("title"):
         return False, "title requerido"
-    price = row.get("price")
+    price = row.get("purchase_price")
     if price is not None and price < 0:
-        return False, "price negativo"
+        return False, "purchase_price negativo"
     return True, None

--- a/tests/test_santaplanta_apply.py
+++ b/tests/test_santaplanta_apply.py
@@ -1,0 +1,53 @@
+import hashlib
+import pandas as pd
+import pytest
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from db.base import Base
+from db.models import Inventory, SupplierPriceHistory, SupplierProduct, Variant
+from services.ingest import upsert
+
+
+def _sku(spid: str) -> str:
+    return "SP-" + hashlib.sha1(spid.encode()).hexdigest()[:8].upper()
+
+
+@pytest.mark.asyncio
+async def test_apply_crea_registros_y_historial():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    df1 = pd.DataFrame({
+        "supplier_product_id": ["1"],
+        "title": ["P"],
+        "purchase_price": [10],
+        "sale_price": [20],
+    })
+    df2 = pd.DataFrame({
+        "supplier_product_id": ["1"],
+        "title": ["P"],
+        "purchase_price": [15],
+        "sale_price": [25],
+    })
+    async with Session() as session:
+        await upsert.upsert_supplier_rows(df1.to_dict("records"), session, "santa-planta", dry_run=False)
+    async with Session() as session:
+        await upsert.upsert_supplier_rows(df2.to_dict("records"), session, "santa-planta", dry_run=False)
+    async with Session() as session:
+        sp = await session.scalar(select(SupplierProduct))
+        variant = await session.scalar(select(Variant))
+        inventory = await session.scalar(select(Inventory))
+        history_count = await session.scalar(select(func.count(SupplierPriceHistory.id)))
+        last_history = (
+            await session.execute(
+                select(SupplierPriceHistory).order_by(SupplierPriceHistory.id.desc())
+            )
+        ).scalar()
+    assert sp.supplier_product_id == "1"
+    assert variant.sku == _sku("1")
+    assert inventory.stock_qty == 0
+    assert history_count == 2
+    assert round(last_history.delta_purchase_pct, 2) == 50.0
+    assert round(last_history.delta_sale_pct, 2) == 25.0

--- a/tests/test_santaplanta_detect.py
+++ b/tests/test_santaplanta_detect.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from services.ingest import detect
+
+
+def test_detecta_santa_planta(tmp_path):
+    df = pd.DataFrame({
+        "ID": ["1"],
+        "Agrupamiento": ["A"],
+        "Familia": ["F"],
+        "SubFamilia": ["S"],
+        "Producto": ["P"],
+        "Compra Minima": [1],
+        "Stock": [0],
+        "PrecioDeCompra": [10],
+        "PrecioDeVenta": [20],
+    })
+    file_path = tmp_path / "ListaPrecios_export_test.xlsx"
+    df.to_excel(file_path, sheet_name="data", index=False)
+    detected = detect.detect_supplier(file_path)
+    assert detected == "santa-planta"

--- a/tests/test_santaplanta_dryrun.py
+++ b/tests/test_santaplanta_dryrun.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pytest
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from db.base import Base
+from db.models import SupplierProduct, Variant
+from services.ingest import upsert
+
+
+@pytest.mark.asyncio
+async def test_dryrun_no_persist(tmp_path):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    df = pd.DataFrame({
+        "supplier_product_id": ["1"],
+        "title": ["P"],
+        "purchase_price": [10],
+        "sale_price": [20],
+    })
+    async with Session() as session:
+        await upsert.upsert_supplier_rows(df.to_dict("records"), session, "santa-planta", dry_run=True)
+    async with Session() as session:
+        count_sp = await session.scalar(select(func.count(SupplierProduct.id)))
+        count_var = await session.scalar(select(func.count(Variant.id)))
+    assert count_sp == 0
+    assert count_var == 0

--- a/tests/test_santaplanta_mapping.py
+++ b/tests/test_santaplanta_mapping.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import yaml
+from services.ingest import mapping
+
+
+def test_mapeo_campos_santa_planta():
+    with open("config/suppliers/santa-planta.yml", "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    df = pd.DataFrame({
+        "ID": ["1"],
+        "Producto": ["P"],
+        "Agrupamiento": ["A"],
+        "Familia": ["F"],
+        "SubFamilia": ["S"],
+        "Compra Minima": [1],
+        "Stock": [0],
+        "PrecioDeCompra": [10],
+        "PrecioDeVenta": [20],
+    })
+    mapped = mapping.map_columns(df, cfg)
+    assert {"supplier_product_id", "title", "purchase_price", "sale_price"}.issubset(mapped.columns)


### PR DESCRIPTION
## Summary
- add Santa Planta supplier config and ingestion support
- track supplier products and price history
- document monthly Santa Planta workflow and CLI options

## Testing
- `pytest` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689e50e74c2c8330afeb2fb517df7189