### PR TITLE
Integrar intents con handlers y fallback de IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ En el chat o vía API se pueden usar:
 
 La ruta `GET /actions` devuelve acciones rápidas.
 
+## Flujo de chat e intents
+
+El endpoint de chat y el WebSocket analizan cada mensaje para detectar comandos.
+
+1. Si el texto corresponde a un intent conocido, se ejecuta el handler asociado y se retorna una respuesta estructurada.
+2. Cuando el intent es desconocido, se invoca `AIRouter.run` con la tarea `Task.SHORT_ANSWER` para generar una contestación libre mediante IA.
+
+El WebSocket utiliza la misma lógica para cada mensaje entrante y cierra la conexión de forma limpia ante una desconexión del cliente.
+
+Cuando el proveedor de IA elegido no soporta la tarea solicitada, el ruteador registra una advertencia y cambia a **Ollama** como alternativa.
+
 ## Carga de catálogo desde proveedores (ingesta)
 
 Permite subir archivos `.csv` o `.xlsx` de distintos proveedores para poblar el catálogo interno.

--- a/ai/router.py
+++ b/ai/router.py
@@ -1,7 +1,8 @@
 """Fachada para enrutar peticiones de IA."""
+
 from __future__ import annotations
 
-from typing import Iterable
+import logging
 
 from agent_core.config import Settings
 from .policy import choose
@@ -28,4 +29,9 @@ class AIRouter:
         if name == "openai" and not self.settings.ai_allow_external:
             name = "ollama"
         provider = self._providers[name]
+        if not provider.supports(task):
+            logging.warning(
+                "Proveedor %s no soporta la tarea %s, usando ollama", name, task
+            )
+            provider = self._providers["ollama"]
         return "".join(provider.generate(prompt))

--- a/services/intents/router.py
+++ b/services/intents/router.py
@@ -1,12 +1,35 @@
-"""Enrutador de intents mínimo."""
+"""Enrutador de intents y dispatcher de handlers."""
+
 from __future__ import annotations
+
+from typing import Any, Callable
 
 from agent_core import nlu
 
+from . import handlers
+
+# Mapa de intents a funciones handler.
+HANDLERS: dict[str, Callable[[], dict[str, Any]]] = {
+    "help": handlers.handle_help,
+}
+
 
 def route(message: str) -> str:
-    """Devuelve el intent detectado."""
+    """Devuelve el intent detectado a partir del mensaje."""
     parsed = nlu.parse(message)
     if parsed:
         return parsed.command
     return "unknown"
+
+
+def handle(message: str) -> dict[str, Any]:
+    """Procesa el mensaje ejecutando el handler asociado al intent.
+
+    Levanta ``KeyError`` si el intent no está registrado.
+    """
+
+    intent = route(message)
+    handler = HANDLERS.get(intent)
+    if handler:
+        return handler()
+    raise KeyError(intent)

--- a/services/routers/ws.py
+++ b/services/routers/ws.py
@@ -1,15 +1,33 @@
-"""WebSocket de chat básico."""
-from fastapi import APIRouter, WebSocket
+"""WebSocket de chat con ruteo de intents e IA de respaldo."""
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import logging
+
+from agent_core.config import settings
+from ai.router import AIRouter
+from ai.types import Task
+from services.intents.router import handle
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.websocket("/ws/chat")
 async def ws_chat(socket: WebSocket) -> None:
     await socket.accept()
+    ai = AIRouter(settings)
     try:
         while True:
             data = await socket.receive_text()
-            await socket.send_text(f"echo: {data}")
+            try:
+                result = handle(data)
+            except KeyError:
+                reply = ai.run(Task.SHORT_ANSWER.value, data)
+                result = {"message": reply}
+            await socket.send_json(result)
+    except WebSocketDisconnect:
+        await socket.close(code=1000)
     except Exception:
-        await socket.close()
+        logger.exception("Error inesperado en ws_chat")
+        await socket.close(code=1011)
+        raise


### PR DESCRIPTION
## Resumen
- Conectar intents con sus handlers y exponer función `handle`
- Chat HTTP y WebSocket ejecutan handlers y usan IA para intents desconocidos
- AIRouter verifica soporte de tareas y cae a Ollama cuando es necesario
- Documentación ampliada sobre el flujo de chat e intents

## Testing
- `ruff check services/intents/router.py services/routers/chat.py services/routers/ws.py ai/router.py`
- `pytest` *(falla: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_689e546d45088330b90d5ecd0fd1d1b4