### PR TITLE
feat: gestión básica de proveedores y categorías

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,33 @@ Cada ingestión registra los precios de compra y venta en la tabla `supplier_pri
 
 El catálogo base ingresa con `stock_qty=0` en `inventory`. La sincronización de stock con proveedores se agregará más adelante.
 
+## Gestión de proveedores
+
+La API expone endpoints para administrar proveedores externos:
+
+- `GET /suppliers` lista todos los proveedores con la cantidad de archivos cargados.
+- `POST /suppliers` crea un nuevo proveedor validando que el `slug` sea único.
+- `PATCH /suppliers/{id}` actualiza el nombre de un proveedor existente.
+- `GET /suppliers/{id}/files` muestra los archivos cargados por un proveedor.
+
+Estos recursos facilitan la organización de las distintas listas de precio y su historial.
+
+## Categorías desde proveedor
+
+Se puede proponer y generar la jerarquía de categorías a partir de un archivo de proveedor:
+
+```bash
+POST /categories/generate-from-supplier-file
+{
+  "file_id": 1,
+  "dry_run": true
+}
+```
+
+Con `dry_run=true` solo se informa qué rutas de categoría se detectarían. Si se envía `dry_run=false`, las categorías faltantes se crean respetando la jerarquía `parent_id`.
+
+Además, `GET /categories` lista las categorías con su ruta completa y `GET /categories/search?q=` permite búsquedas parciales.
+
 ## IA híbrida
 
 La política por defecto utiliza:

--- a/services/api.py
+++ b/services/api.py
@@ -3,12 +3,13 @@ from fastapi import FastAPI
 
 from agent_core.config import settings
 from ai.router import AIRouter
-from .routers import actions, chat, ws
+from .routers import actions, chat, ws, catalog
 
 app = FastAPI(title="Growen")
 app.include_router(chat.router)
 app.include_router(actions.router)
 app.include_router(ws.router)
+app.include_router(catalog.router)
 
 
 @app.get("/health")

--- a/services/routers/catalog.py
+++ b/services/routers/catalog.py
@@ -1,0 +1,241 @@
+"""Endpoints para gestionar proveedores y categorías."""
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Category, Supplier, SupplierFile, SupplierPriceHistory, SupplierProduct
+from db.session import get_session
+
+router = APIRouter(tags=["catalog"])
+
+
+# ------------------------------- Proveedores -------------------------------
+
+
+class SupplierCreate(BaseModel):
+    slug: str
+    name: str
+
+
+class SupplierUpdate(BaseModel):
+    name: str
+
+
+@router.get("/suppliers")
+async def list_suppliers(
+    session: AsyncSession = Depends(get_session),
+) -> List[dict]:
+    """Lista proveedores con estadísticas básicas."""
+
+    result = await session.execute(
+        select(
+            Supplier,
+            func.count(SupplierFile.id).label("files_count"),
+            func.max(SupplierFile.uploaded_at).label("last_upload"),
+        ).outerjoin(SupplierFile, SupplierFile.supplier_id == Supplier.id)
+        .group_by(Supplier.id)
+        .order_by(Supplier.id)
+    )
+    rows = result.all()
+    return [
+        {
+            "id": supplier.id,
+            "slug": supplier.slug,
+            "name": supplier.name,
+            "created_at": supplier.created_at.isoformat(),
+            "last_upload_at": last_upload.isoformat() if last_upload else None,
+            "files_count": files_count,
+        }
+        for supplier, files_count, last_upload in rows
+    ]
+
+
+@router.get("/suppliers/{supplier_id}/files")
+async def list_supplier_files(
+    supplier_id: int, session: AsyncSession = Depends(get_session)
+) -> List[dict]:
+    """Lista archivos subidos por un proveedor."""
+
+    result = await session.execute(
+        select(SupplierFile).where(SupplierFile.supplier_id == supplier_id)
+    )
+    files = result.scalars().all()
+    return [
+        {
+            "id": f.id,
+            "filename": f.filename,
+            "sha256": f.sha256,
+            "rows": f.rows,
+            "processed": f.processed,
+            "dry_run": f.dry_run,
+            "uploaded_at": f.uploaded_at.isoformat(),
+        }
+        for f in files
+    ]
+
+
+@router.post("/suppliers")
+async def create_supplier(
+    req: SupplierCreate, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Crea un nuevo proveedor validando unicidad de slug."""
+
+    existing = await session.scalar(select(Supplier).where(Supplier.slug == req.slug))
+    if existing:
+        raise HTTPException(status_code=400, detail="slug ya existe")
+    supplier = Supplier(slug=req.slug, name=req.name)
+    session.add(supplier)
+    await session.commit()
+    await session.refresh(supplier)
+    return {
+        "id": supplier.id,
+        "slug": supplier.slug,
+        "name": supplier.name,
+        "created_at": supplier.created_at.isoformat(),
+    }
+
+
+@router.patch("/suppliers/{supplier_id}")
+async def update_supplier(
+    supplier_id: int, req: SupplierUpdate, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Actualiza el nombre de un proveedor existente."""
+
+    supplier = await session.get(Supplier, supplier_id)
+    if not supplier:
+        raise HTTPException(status_code=404, detail="Proveedor no encontrado")
+    supplier.name = req.name
+    await session.commit()
+    await session.refresh(supplier)
+    return {
+        "id": supplier.id,
+        "slug": supplier.slug,
+        "name": supplier.name,
+    }
+
+
+# ------------------------------- Categorías -------------------------------
+
+
+class CategoryGenRequest(BaseModel):
+    file_id: int
+    dry_run: bool = True
+
+
+def _build_category_path(cat: Category, lookup: dict[int, Category]) -> str:
+    parts: List[str] = [cat.name]
+    parent_id = cat.parent_id
+    while parent_id:
+        parent = lookup[parent_id]
+        parts.append(parent.name)
+        parent_id = parent.parent_id
+    return ">".join(reversed(parts))
+
+
+@router.get("/categories")
+async def list_categories(
+    session: AsyncSession = Depends(get_session),
+) -> List[dict]:
+    """Lista categorías con su jerarquía completa."""
+
+    result = await session.execute(select(Category))
+    cats = result.scalars().all()
+    lookup = {c.id: c for c in cats}
+    return [
+        {
+            "id": c.id,
+            "name": c.name,
+            "parent_id": c.parent_id,
+            "path": _build_category_path(c, lookup),
+        }
+        for c in cats
+    ]
+
+
+@router.get("/categories/search")
+async def search_categories(q: str, session: AsyncSession = Depends(get_session)) -> List[dict]:
+    """Busca categorías por nombre o path parcial."""
+
+    result = await session.execute(
+        select(Category).where(Category.name.ilike(f"%{q}%"))
+    )
+    cats = result.scalars().all()
+    lookup = {c.id: c for c in cats}
+    return [
+        {
+            "id": c.id,
+            "name": c.name,
+            "parent_id": c.parent_id,
+            "path": _build_category_path(c, lookup),
+        }
+        for c in cats
+    ]
+
+
+@router.post("/categories/generate-from-supplier-file")
+async def generate_categories(
+    req: CategoryGenRequest, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Genera categorías a partir de un archivo de proveedor."""
+
+    # Obtener productos asociados al archivo
+    stmt = (
+        select(SupplierProduct)
+        .join(SupplierPriceHistory, SupplierPriceHistory.supplier_product_fk == SupplierProduct.id)
+        .where(SupplierPriceHistory.file_fk == req.file_id)
+    )
+    result = await session.execute(stmt)
+    products = result.scalars().all()
+
+    paths = set()
+    for p in products:
+        levels = [
+            lvl
+            for lvl in [p.category_level_1, p.category_level_2, p.category_level_3]
+            if lvl
+        ]
+        if levels:
+            paths.add(">".join(levels))
+
+    # Categorías existentes para comparar
+    existing_result = await session.execute(select(Category))
+    existing_cats = existing_result.scalars().all()
+    lookup = {c.id: c for c in existing_cats}
+    existing_paths = {_build_category_path(c, lookup) for c in existing_cats}
+
+    proposed = []
+    created: List[str] = []
+    skipped: List[str] = []
+
+    for path in sorted(paths):
+        if path in existing_paths:
+            proposed.append({"path": path, "status": "exists"})
+            skipped.append(path)
+            continue
+        proposed.append({"path": path, "status": "new"})
+        if req.dry_run:
+            continue
+        # Crear jerarquía faltante
+        parent_id = None
+        for name in path.split(">"):
+            q = select(Category).where(
+                Category.name == name, Category.parent_id == parent_id
+            )
+            cat = await session.scalar(q)
+            if not cat:
+                cat = Category(name=name, parent_id=parent_id)
+                session.add(cat)
+                await session.flush()
+            parent_id = cat.id
+        created.append(path)
+        existing_paths.add(path)
+
+    if not req.dry_run:
+        await session.commit()
+
+    return {"proposed": proposed, "created": created, "skipped": skipped}

--- a/tests/test_suppliers_api.py
+++ b/tests/test_suppliers_api.py
@@ -1,0 +1,62 @@
+import os
+import asyncio
+
+# Configurar DB en memoria antes de importar la app
+os.environ["DB_URL"] = "sqlite+aiosqlite:///:memory:"
+
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.api import app
+from db.base import Base
+from db.session import engine, SessionLocal
+from db.models import Supplier, SupplierFile
+
+
+async def _init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+asyncio.get_event_loop().run_until_complete(_init_db())
+
+client = TestClient(app)
+
+
+def test_supplier_crud() -> None:
+    # Crear proveedor
+    resp = client.post("/suppliers", json={"slug": "sp", "name": "Santa Planta"})
+    assert resp.status_code == 200
+    data = resp.json()
+    supplier_id = data["id"]
+
+    # Listar proveedores
+    resp = client.get("/suppliers")
+    assert resp.status_code == 200
+    assert any(s["slug"] == "sp" for s in resp.json())
+
+    # Insertar archivo asociado para probar listado de files
+    async def _add_file() -> None:
+        async with SessionLocal() as session:  # type: AsyncSession
+            file = SupplierFile(
+                supplier_id=supplier_id,
+                filename="test.csv",
+                sha256="abc",
+                rows=1,
+            )
+            session.add(file)
+            await session.commit()
+    asyncio.get_event_loop().run_until_complete(_add_file())
+
+    # Listar archivos del proveedor
+    resp = client.get(f"/suppliers/{supplier_id}/files")
+    assert resp.status_code == 200
+    files = resp.json()
+    assert files and files[0]["filename"] == "test.csv"
+
+    # Actualizar nombre del proveedor
+    resp = client.patch(
+        f"/suppliers/{supplier_id}", json={"name": "Proveedor X"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Proveedor X"


### PR DESCRIPTION
## Resumen
- exponer endpoints REST para listar y administrar proveedores
- generar y consultar categorías a partir de archivos de proveedores
- documentar los nuevos recursos y agregar pruebas del API de proveedores

## Testing
- `pytest tests/test_suppliers_api.py -q` *(falla: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi sqlalchemy aiosqlite -q` *(falla: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689e588730bc8330a9da6777c60f8963