### PR TITLE
fix: corregir formato de dependencias en pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,18 @@ authors = [{name = "Growen"}]
 requires-python = ">=3.11"
 readme = "README.md"
 
-[project.dependencies]
-fastapi = "^0.111.0"
-uvicorn = {version = "^0.30.1", extras = ["standard"]}
-sqlalchemy = "^2.0.29"
-alembic = "^1.13.1"
-psycopg = {version = "^3.1.18", extras = ["binary"]}
-pydantic-settings = "^2.2.1"
-typer = "^0.12.3"
-websockets = "^12.0"
-pandas = "^2.2.2"
-openpyxl = "^3.1.2"
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.30.1",
+    "sqlalchemy>=2.0.29",
+    "alembic>=1.13.1",
+    "psycopg[binary]>=3.1.18",
+    "pydantic-settings>=2.2.1",
+    "typer>=0.12.3",
+    "websockets>=12.0",
+    "pandas>=2.2.2",
+    "openpyxl>=3.1.2",
+]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- convert project dependencies to PEP 621 compliant list

## Testing
- `pip install -e ".[dev]"` *(failed: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_689f3f5ad1f88330aad65234a45a847e