### PR TITLE
docs: detallar paquetes en instalacion local

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Agente para gestión de catálogo y stock de Nice Grow con interfaz de chat web 
 
 ## Instalación local
 
+Antes de instalar dependencias, `pyproject.toml` debe listar los paquetes o usar un directorio `src/`.
+Este repositorio mantiene sus módulos en la raíz, así que es necesario declararlos explícitamente:
+
+```toml
+[tool.setuptools.packages.find]
+include = ["agent_core", "ai", "cli", "adapters", "services", "db"]
+```
+
+Si se prefiere un layout `src/`, trasladá las carpetas anteriores a `src/` y añadí `where = ["src"]` en la misma sección.
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate


### PR DESCRIPTION
## Resumen
- Aclarar que `pyproject.toml` debe listar paquetes o usar `src/`
- Agregar ejemplo de `[tool.setuptools.packages.find]` con los módulos del repositorio

## Testing
- `pytest` *(falla: no pudo conectarse a la base de datos `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689f42d8fbe483308fae8cfe4f205e09