### PR TITLE
Configura descubrimiento de paquetes en setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,6 @@ dev = [
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["ai", "db", "cli", "data", "infra", "config", "alembic", "adapters", "frontend", "services", "agent_core"]


### PR DESCRIPTION
## Resumen
- Define explicitamente los paquetes a incluir durante la instalación con setuptools.

## Pruebas
- `pip install -e .[dev]`
- `pytest` *(falla: no se pudo conectar a PostgreSQL durante la carga de pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_689f42b9f76883308eacecf775b1e174