### PR TITLE
chore: cargar variables desde .env automáticamente

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e .[dev]
 cp .env.example .env
+# las variables de entorno se cargan automáticamente desde .env
 # crear base de datos growen en PostgreSQL
 alembic -c ./alembic.ini upgrade head
 uvicorn services.api:app --reload
@@ -58,7 +59,7 @@ Levanta PostgreSQL, API en `:8000` y frontend en `:5173`.
 
 ## Migraciones (Alembic)
 
-Las migraciones se administran con Alembic usando la carpeta `db/migrations`. La URL `DB_URL` se toma de `.env`.
+Las migraciones se administran con Alembic usando la carpeta `db/migrations`. La URL `DB_URL` se toma automáticamente de `.env` gracias a `python-dotenv`.
 
 ```bash
 # Crear una nueva revisión a partir de los modelos

--- a/agent_core/config.py
+++ b/agent_core/config.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from dotenv import load_dotenv
+
+# Carga automática de variables definidas en .env
+load_dotenv()
 
 
 @dataclass

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from sqlalchemy.engine import Connection
+from dotenv import load_dotenv
 
 # Config Alembic
 config = context.config
@@ -11,6 +12,9 @@ config = context.config
 # Logging (si alembic.ini tiene secciones de logging)
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
+
+# === Cargar variables desde .env ===
+load_dotenv()
 
 # === Cargar DB_URL desde entorno ===
 db_url = os.getenv("DB_URL")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "ruff>=0.4.2",
     "black>=24.3.0",
     "pytest>=8.1.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Resumen
- añade `python-dotenv` a las dependencias de desarrollo
- carga automática de `.env` en Alembic y en la configuración del agente
- documenta el uso de `.env` en README

## Testing
- `python -m alembic -c ./alembic.ini upgrade head` *(falla: connection refused)*
- `pytest` *(falla: no pudo conectar a la base de datos)*

------
https://chatgpt.com/codex/tasks/task_e_689f5e1da1d08330a3a32af188c1ab27