### PR TITLE
Cargar DB_URL desde .env en Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Este repositorio mantiene sus módulos en la raíz, así que es necesario declar
 ```toml
 [tool.setuptools.packages.find]
 include = ["agent_core", "ai", "cli", "adapters", "services", "db"]
+```bash
+# Crear una nueva revisión a partir de los modelos
+alembic -c ./alembic.ini revision -m "descripcion" --autogenerate
+
+# Aplicar las migraciones pendientes
+alembic -c ./alembic.ini upgrade head
+
+# Revertir la última migración
+alembic -c ./alembic.ini downgrade -1
 ```
 
 Si se prefiere un layout `src/`, trasladá las carpetas anteriores a `src/` y añadí `where = ["src"]` en la misma sección.
@@ -59,7 +68,11 @@ Levanta PostgreSQL, API en `:8000` y frontend en `:5173`.
 
 ## Migraciones (Alembic)
 
-Las migraciones se administran con Alembic usando la carpeta `db/migrations`. La URL `DB_URL` se toma automáticamente de `.env` gracias a `python-dotenv`.
+Las migraciones se administran con Alembic usando la carpeta `db/migrations`. El archivo `env.py` carga automáticamente las
+variables definidas en `.env`, por lo que no es necesario configurar la URL en `alembic.ini`.
+
+1. Copiá `.env.example` a `.env` y completá `DB_URL`.
+2. Ejecutá `alembic -c ./alembic.ini upgrade head` para aplicar el esquema inicial.
 
 ```bash
 # Crear una nueva revisión a partir de los modelos

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,7 +1,9 @@
 [alembic]
 script_location = db/migrations
 prepend_sys_path = .
-sqlalchemy.url = %(DB_URL)s
+# sqlalchemy.url se sobreescribe desde .env en db/migrations/env.py
+# sqlalchemy.url = %(DB_URL)s
+sqlalchemy.url = postgresql://placeholder
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -3,7 +3,6 @@ from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from sqlalchemy.engine import Connection
 from dotenv import load_dotenv
 
 # Config Alembic
@@ -20,11 +19,14 @@ load_dotenv()
 db_url = os.getenv("DB_URL")
 if db_url:
     config.set_main_option("sqlalchemy.url", db_url)
+else:
+    raise RuntimeError("DB_URL no definida en entorno/.env")
 
 # === Importar metadatos del proyecto ===
 try:
     from db.base import Base
     import db.models  # noqa: F401
+
     target_metadata = Base.metadata
 except Exception:
     # Fallback seguro: sin metadata, autogenerate no funcionará


### PR DESCRIPTION
## Resumen
- Carga `DB_URL` desde `.env` y detiene migraciones si falta
- Ajusta `alembic.ini` para evitar interpolación de variables
- Documenta los pasos para ejecutar migraciones con `.env`

## Testing
- `ruff check db/migrations/env.py`
- `black db/migrations/env.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f604447f8833096dd612861fc0291