### PR TITLE
Evitar interpolación de DB_URL en Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,11 @@ Levanta PostgreSQL, API en `:8000` y frontend en `:5173`.
 Las migraciones se administran con Alembic usando la carpeta `db/migrations`. El archivo `env.py` carga automáticamente las
 variables definidas en `.env`, por lo que no es necesario configurar la URL en `alembic.ini`.
 
-1. Copiá `.env.example` a `.env` y completá `DB_URL`.
-2. Ejecutá `alembic -c ./alembic.ini upgrade head` para aplicar el esquema inicial.
-
 ```bash
+cp .env.example .env   # en Windows usar: copy .env.example .env
+# Completar DB_URL en .env
+alembic -c ./alembic.ini upgrade head
+
 # Crear una nueva revisión a partir de los modelos
 alembic -c ./alembic.ini revision -m "descripcion" --autogenerate
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,9 +1,7 @@
 [alembic]
 script_location = db/migrations
 prepend_sys_path = .
-# sqlalchemy.url se sobreescribe desde .env en db/migrations/env.py
-# sqlalchemy.url = %(DB_URL)s
-sqlalchemy.url = postgresql://placeholder
+# sqlalchemy.url = configurada por db/migrations/env.py
 
 [loggers]
 keys = root,sqlalchemy,alembic


### PR DESCRIPTION
## Resumen
- cargar `DB_URL` desde `.env` y crear el engine manualmente en `env.py`
- alejar `alembic.ini` de la interpolación dejando la URL a cargo de `env.py`
- documentar pasos de migración con carga automática de `.env`

## Testing
- `DB_URL='postgresql://user:pass%3Dword@localhost/db' alembic -c ./alembic.ini upgrade head --sql` ✅
- `pytest` ⚠️ falla: connection to server at "127.0.0.1" refused


------
https://chatgpt.com/codex/tasks/task_e_689f63c99c808330b2edf24fa7fb9186