### PR TITLE
feat: agregar scripts de inicio y parada con chequeos

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ Levanta API y frontend al mismo tiempo.
 - **CMD**: doble clic en `start.bat`.
 - **PowerShell**: `./start.ps1` (si `ExecutionPolicy` lo bloquea: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`).
 
+`start.bat` valida que los puertos `8000` y `5173` estén libres antes de iniciar.
+Cada servicio se abre en una ventana separada con `cmd /k` y,
+tras unos segundos, se realiza una petición con `curl` para confirmar
+que respondan:
+
+- **Backend**: `http://localhost:8000/docs`
+- **Frontend**: `http://localhost:5173/`
+
+En consola se muestran mensajes `[OK]` o `[ERROR]` según el estado y las
+ventanas permanecen abiertas incluso si ocurre un fallo.
+
+Para detener los servicios usar `stop.bat` (CMD) o `stop.ps1` (PowerShell),
+que buscan y finalizan los procesos en los puertos `8000` y `5173`.
+
 ### Debian/Ubuntu
 
 ```bash

--- a/stop.bat
+++ b/stop.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+echo Cerrando backend (puerto 8000)...
+set FOUND_BACKEND=
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do (
+    taskkill /PID %%a /F >nul 2>&1
+    set FOUND_BACKEND=1
+)
+if not defined FOUND_BACKEND (
+    echo No se encontró proceso en puerto 8000.
+)
+
+echo Cerrando frontend (puerto 5173)...
+set FOUND_FRONTEND=
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do (
+    taskkill /PID %%a /F >nul 2>&1
+    set FOUND_FRONTEND=1
+)
+if not defined FOUND_FRONTEND (
+    echo No se encontró proceso en puerto 5173.
+)
+
+pause

--- a/stop.ps1
+++ b/stop.ps1
@@ -1,0 +1,19 @@
+Write-Host "Cerrando backend (puerto 8000)..."
+$p8000 = netstat -ano | Select-String ":8000"
+if ($p8000) {
+    $pid = ($p8000 -split '\s+')[-1]
+    Stop-Process -Id $pid -Force
+} else {
+    Write-Host "No se encontró proceso en puerto 8000."
+}
+
+Write-Host "Cerrando frontend (puerto 5173)..."
+$p5173 = netstat -ano | Select-String ":5173"
+if ($p5173) {
+    $pid = ($p5173 -split '\s+')[-1]
+    Stop-Process -Id $pid -Force
+} else {
+    Write-Host "No se encontró proceso en puerto 5173."
+}
+
+Read-Host "Presione Enter para continuar"


### PR DESCRIPTION
## Resumen
- Mantener start.bat abierto, verificar puertos 8000 y 5173 y confirmar disponibilidad con curl.
- Añadir stop.bat y stop.ps1 para finalizar backend y frontend por puerto.
- Actualizar README con instrucciones de inicio y parada.

## Pruebas
- `pytest` *(errores: ModuleNotFoundError: No module named 'dotenv', 'pandas', 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689f76831ccc8330b3f00264a7612160