### PR TITLE
Mejoras en scripts de inicio/stop con logging y verificación

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,23 @@ Levanta API y frontend al mismo tiempo.
 - **CMD**: doble clic en `start.bat`.
 - **PowerShell**: `./start.ps1` (si `ExecutionPolicy` lo bloquea: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`).
 
-`start.bat` valida que los puertos `8000` y `5173` estén libres antes de iniciar.
-Cada servicio se abre en una ventana separada con `cmd /k` y,
-tras unos segundos, se realiza una petición con `curl` para confirmar
-que respondan:
+`start.bat` ejecuta primero `stop.bat` para liberar los puertos `8000` y `5173`,
+valida que sigan libres y luego inicia backend y frontend en ventanas
+separadas con `cmd /k`. Toda la salida se muestra en consola y se agrega a
+`logs/server.log` con marca temporal. Tras unos segundos se realiza una
+petición con `curl` para confirmar que respondan:
 
 - **Backend**: `http://localhost:8000/docs`
 - **Frontend**: `http://localhost:5173/`
 
 En consola se muestran mensajes `[OK]` o `[ERROR]` según el estado y las
-ventanas permanecen abiertas incluso si ocurre un fallo.
+ventanas permanecen abiertas incluso si ocurre un fallo. El resultado de cada
+inicio queda registrado en `logs/server.log` con entradas como
+`[YYYY-MM-DD HH:MM:SS] START backend: OK`.
 
-Para detener los servicios usar `stop.bat` (CMD) o `stop.ps1` (PowerShell),
-que buscan y finalizan los procesos en los puertos `8000` y `5173`.
+Para detener los servicios usar `stop.bat` (CMD) o `stop.ps1` (PowerShell);
+ambos cierran los procesos en `8000` y `5173` y registran la acción en el
+mismo archivo de log.
 
 ### Debian/Ubuntu
 

--- a/start.bat
+++ b/start.bat
@@ -5,10 +5,24 @@ set ERROR_FLAG=0
 REM ── Ir a la raíz del repo (ruta de este .bat)
 cd /d "%~dp0"
 
+REM ── Crear carpeta de logs y archivo
+if not exist "logs" mkdir logs
+set LOG_FILE=logs\server.log
+
+REM ── Función para mostrar y registrar mensajes
+set LOG_TS=
+goto :skiplog
+:log
+for /f %%i in ('powershell -NoProfile -Command "Get-Date -Format \"yyyy-MM-dd HH:mm:ss\""') do set LOG_TS=%%i
+echo %~1
+echo [%LOG_TS%] %~1>> "%LOG_FILE%"
+exit /b
+:skiplog
+
 REM ── Verificar venv
 if not exist ".\.venv\Scripts\activate.bat" (
-  echo [WARN] No existe .venv. Cree el entorno primero: python -m venv .venv
-  echo        Luego: .\.venv\Scripts\activate.bat && pip install -e .
+  call :log "[WARN] No existe .venv. Cree el entorno primero: python -m venv .venv"
+  call :log "        Luego: .\.venv\Scripts\activate.bat && pip install -e ."
   pause
   goto :eof
 )
@@ -18,7 +32,7 @@ call ".\.venv\Scripts\activate.bat"
 
 REM ── Verificar .env y variables básicas
 if not exist ".env" (
-  echo [ERROR] Falta .env (copie .env.example a .env y complete DB_URL/IA).
+  call :log "[ERROR] Falta .env (copie .env.example a .env y complete DB_URL/IA)."
   pause
   goto :eof
 )
@@ -29,28 +43,33 @@ for /f "usebackq tokens=1,2 delims==" %%A in (".env") do (
 )
 
 if "%DB_URL%"=="" (
-  echo [ERROR] Falta DB_URL en .env
+  call :log "[ERROR] Falta DB_URL en .env"
   pause
   goto :eof
 )
 if "%OLLAMA_MODEL%"=="" (
-  echo [WARN] Falta OLLAMA_MODEL en .env
+  call :log "[WARN] Falta OLLAMA_MODEL en .env"
 )
+
+REM ── Detener servicios previos
+call stop.bat -q >nul 2>&1
 
 REM ── Iniciar backend si el puerto está libre
 netstat -ano | findstr ":8000" >nul
 if %errorlevel%==0 (
-  echo [ERROR] Puerto 8000 ocupado. No se inicia backend.
+  call :log "[ERROR] Puerto 8000 ocupado. No se inicia backend."
   set ERROR_FLAG=1
 ) else (
-  echo [INFO] Iniciando backend...
-  start "Growen API" cmd /k "uvicorn services.api:app --reload"
+  call :log "[INFO] Iniciando backend..."
+  start "Growen API" cmd /k "powershell -Command \"uvicorn services.api:app --reload 2^>^&1 ^| Tee-Object -FilePath \"%LOG_FILE%\" -Append\""
   timeout /t 5 /nobreak >nul
   curl --silent --fail http://localhost:8000/docs >nul 2>&1
   if %errorlevel%==0 (
     echo [OK] Backend en línea
+    call :log "START backend: OK"
   ) else (
     echo [ERROR] Backend no responde
+    call :log "START backend: ERROR"
     set ERROR_FLAG=1
   )
 )
@@ -58,7 +77,7 @@ if %errorlevel%==0 (
 REM ── Frontend: instalar deps si faltan
 set FRONTEND_DIR=%~dp0frontend
 if not exist "%FRONTEND_DIR%\node_modules" (
-  echo [INFO] Instalando dependencias frontend...
+  call :log "[INFO] Instalando dependencias frontend..."
   pushd "%FRONTEND_DIR%"
   npm install
   popd
@@ -67,23 +86,28 @@ if not exist "%FRONTEND_DIR%\node_modules" (
 REM ── Iniciar frontend si el puerto está libre
 netstat -ano | findstr ":5173" >nul
 if %errorlevel%==0 (
-  echo [ERROR] Puerto 5173 ocupado. No se inicia frontend.
+  call :log "[ERROR] Puerto 5173 ocupado. No se inicia frontend."
   set ERROR_FLAG=1
 ) else (
-  echo [INFO] Iniciando frontend...
-  start "Growen Frontend" cmd /k "cd /d ^"%FRONTEND_DIR%^" && npm run dev"
+  call :log "[INFO] Iniciando frontend..."
+  start "Growen Frontend" cmd /k "powershell -Command \"Set-Location -Path \"%FRONTEND_DIR%\"; npm run dev 2^>^&1 ^| Tee-Object -FilePath \"%LOG_FILE%\" -Append\""
   timeout /t 5 /nobreak >nul
   curl --silent --fail http://localhost:5173/ >nul 2>&1
   if %errorlevel%==0 (
     echo [OK] Frontend en línea
+    call :log "START frontend: OK"
   ) else (
     echo [ERROR] Frontend no responde
+    call :log "START frontend: ERROR"
     set ERROR_FLAG=1
   )
 )
 
 if %ERROR_FLAG%==1 (
   echo.
-  echo [INFO] Ocurrieron errores. Presione una tecla para continuar.
-  pause
+  echo [INFO] Ocurrieron errores.
 )
+
+pause
+
+goto :eof

--- a/stop.bat
+++ b/stop.bat
@@ -1,24 +1,16 @@
 @echo off
 setlocal
 
-echo Cerrando backend (puerto 8000)...
-set FOUND_BACKEND=
-for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do (
-    taskkill /PID %%a /F >nul 2>&1
-    set FOUND_BACKEND=1
-)
-if not defined FOUND_BACKEND (
-    echo No se encontró proceso en puerto 8000.
-)
+REM ── Modo silencioso para uso desde start.bat
+if "%1"=="-q" set QUIET=1
 
-echo Cerrando frontend (puerto 5173)...
-set FOUND_FRONTEND=
-for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do (
-    taskkill /PID %%a /F >nul 2>&1
-    set FOUND_FRONTEND=1
-)
-if not defined FOUND_FRONTEND (
-    echo No se encontró proceso en puerto 5173.
-)
+if not exist logs mkdir logs
 
-pause
+echo [%date% %time%] Cerrando backend (puerto 8000)... >> logs\server.log
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do taskkill /PID %%a /F
+
+echo [%date% %time%] Cerrando frontend (puerto 5173)... >> logs\server.log
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do taskkill /PID %%a /F
+
+if not defined QUIET pause
+

--- a/stop.ps1
+++ b/stop.ps1
@@ -1,10 +1,17 @@
+$logPath = "logs\server.log"
+if (!(Test-Path logs)) { New-Item -ItemType Directory -Path logs | Out-Null }
+function Log($msg) {
+    Add-Content -Path $logPath -Value ("[{0}] {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $msg)
+}
+
 Write-Host "Cerrando backend (puerto 8000)..."
 $p8000 = netstat -ano | Select-String ":8000"
 if ($p8000) {
     $pid = ($p8000 -split '\s+')[-1]
     Stop-Process -Id $pid -Force
+    Log "STOP backend: proceso $pid cerrado."
 } else {
-    Write-Host "No se encontró proceso en puerto 8000."
+    Log "STOP backend: no se encontró proceso."
 }
 
 Write-Host "Cerrando frontend (puerto 5173)..."
@@ -12,8 +19,8 @@ $p5173 = netstat -ano | Select-String ":5173"
 if ($p5173) {
     $pid = ($p5173 -split '\s+')[-1]
     Stop-Process -Id $pid -Force
+    Log "STOP frontend: proceso $pid cerrado."
 } else {
-    Write-Host "No se encontró proceso en puerto 5173."
+    Log "STOP frontend: no se encontró proceso."
 }
 
-Read-Host "Presione Enter para continuar"


### PR DESCRIPTION
## Resumen
- start.bat ahora crea logs, detiene servicios previos y verifica backend/frontend con curl registrando el resultado.
- stop.bat y stop.ps1 finalizan procesos en 8000/5173 y escriben eventos en logs/server.log.
- README documenta el flujo de arranque y detención con registros.

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689f78854e2483308b9be9515d65615d