### PR TITLE
Fix CORS and align chat/WebSocket routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install
 npm run dev
 ```
 
-En desarrollo, Vite proxya `/ws`, `/chat` y `/actions` hacia `http://localhost:8000`, evitando errores de CORS. El chat abre un WebSocket en `/ws` y, si no está disponible, utiliza `POST /chat`. Para modificar las URLs se puede crear `frontend/.env.development` con `VITE_WS_URL` y `VITE_API_BASE`.
+En desarrollo, Vite proxya `/ws`, `/chat` y `/actions` hacia `http://localhost:8000`, evitando errores de CORS. El backend solo acepta orígenes `http://localhost:5173` y `http://127.0.0.1:5173`, por lo que la UI debe abrirse en esa dirección. El chat abre un WebSocket en `/ws` y, si no está disponible, utiliza `POST /chat`, que admite la variante con o sin barra final para evitar redirecciones 307. Para modificar las URLs se puede crear `frontend/.env.development` con `VITE_WS_URL` y `VITE_API_BASE`.
 
 ## Inicio rápido (1‑clic)
 

--- a/services/api.py
+++ b/services/api.py
@@ -1,11 +1,29 @@
 """Aplicación FastAPI principal del agente."""
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from agent_core.config import settings
 from ai.router import AIRouter
 from .routers import actions, chat, ws, catalog
 
-app = FastAPI(title="Growen")
+# `redirect_slashes=False` evita redirecciones 307 entre `/ruta` y `/ruta/`,
+# lo que rompe las solicitudes *preflight* de CORS.
+app = FastAPI(title="Growen", redirect_slashes=False)
+
+# Permitir que el frontend de desarrollo (Vite) consulte la API sin errores de
+# CORS. Se limita a `localhost:5173` y `127.0.0.1:5173`.
+origins = [
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(chat.router)
 app.include_router(actions.router)
 app.include_router(ws.router)

--- a/services/routers/chat.py
+++ b/services/routers/chat.py
@@ -1,7 +1,7 @@
 """Endpoint de chat síncrono que enruta intents y usa IA de respaldo."""
 
 from fastapi import APIRouter
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from agent_core.config import settings
 from ai.router import AIRouter
@@ -12,9 +12,17 @@ router = APIRouter(prefix="/chat", tags=["chat"])
 
 
 class ChatRequest(BaseModel):
-    message: str
+    """Modelo del cuerpo recibido en `/chat`.
+
+    Se acepta tanto la clave `message` como `text` para compatibilidad con el
+    frontend actual.
+    """
+
+    message: str = Field(alias="text")
+    model_config = ConfigDict(populate_by_name=True)
 
 
+@router.post("")
 @router.post("/")
 async def chat(req: ChatRequest) -> dict[str, object]:
     """Procesa el mensaje y retorna la respuesta del handler o de la IA."""

--- a/services/routers/ws.py
+++ b/services/routers/ws.py
@@ -12,8 +12,19 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.websocket("/ws/chat")
+@router.websocket("/ws")
 async def ws_chat(socket: WebSocket) -> None:
+    """Canal WebSocket principal.
+
+    Se valida el encabezado `Origin` para aceptar solo conexiones provenientes
+    del frontend en `localhost:5173`.
+    """
+
+    origin = socket.headers.get("origin")
+    allowed = {"http://localhost:5173", "http://127.0.0.1:5173"}
+    if origin not in allowed:
+        await socket.close(code=1008)  # violación de política
+        return
     await socket.accept()
     ai = AIRouter(settings)
     try:


### PR DESCRIPTION
## Summary
- allow Vite's dev origin and disable slash redirects
- accept `/chat` without redirect and handle `text` field
- validate WebSocket origin and expose `/ws` path
- document CORS behaviour and required dev URL

## Testing
- `pytest` *(fails: sqlalchemy.exc.OperationalError: connection failed)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f7f990474833098e4200b6fbdce06