### PR TITLE
Corregir manejo de rutas con espacios en start.bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ valida que sigan libres y luego inicia backend y frontend en ventanas
 separadas con `cmd /k`. Toda la salida se muestra en consola y se agrega a
 `logs/server.log` con marca temporal. Tras unos segundos se realiza una
 petición con `curl` para confirmar que respondan:
+El script maneja correctamente rutas con espacios gracias a que las rutas se
+envuelven en comillas simples al invocar PowerShell.
 
 - **Backend**: `http://localhost:8000/docs`
 - **Frontend**: `http://localhost:5173/`

--- a/start.bat
+++ b/start.bat
@@ -61,7 +61,7 @@ if %errorlevel%==0 (
   set ERROR_FLAG=1
 ) else (
   call :log "[INFO] Iniciando backend..."
-  start "Growen API" cmd /k "powershell -Command \"uvicorn services.api:app --reload 2^>^&1 ^| Tee-Object -FilePath \"%LOG_FILE%\" -Append\""
+  start "Growen API" cmd /k "powershell -Command \"uvicorn services.api:app --reload 2^>^&1 ^| Tee-Object -FilePath '%LOG_FILE%' -Append\""
   timeout /t 5 /nobreak >nul
   curl --silent --fail http://localhost:8000/docs >nul 2>&1
   if %errorlevel%==0 (
@@ -90,7 +90,7 @@ if %errorlevel%==0 (
   set ERROR_FLAG=1
 ) else (
   call :log "[INFO] Iniciando frontend..."
-  start "Growen Frontend" cmd /k "powershell -Command \"Set-Location -Path \"%FRONTEND_DIR%\"; npm run dev 2^>^&1 ^| Tee-Object -FilePath \"%LOG_FILE%\" -Append\""
+  start "Growen Frontend" cmd /k "powershell -Command \"Set-Location -Path '%FRONTEND_DIR%'; npm run dev 2^>^&1 ^| Tee-Object -FilePath '%LOG_FILE%' -Append\""
   timeout /t 5 /nobreak >nul
   curl --silent --fail http://localhost:5173/ >nul 2>&1
   if %errorlevel%==0 (


### PR DESCRIPTION
## Resumen
- Usar comillas simples en PowerShell para `-FilePath` del backend y el frontend.
- Ajustar `Set-Location` del frontend para usar comillas simples.
- Documentar que `start.bat` soporta rutas con espacios.

## Pruebas
- `pwsh ./start.bat` *(falla: Unexpected token 'off', falta `cmd.exe` en Linux)*
- `pwsh -Command "Write-Output 'test backend' | Tee-Object -FilePath '/tmp/dir con espacios/logs/backend.log' -Append"`
- `pwsh -Command "Set-Location -Path '/tmp/dir con espacios'; Write-Output 'frontend test' | Tee-Object -FilePath '/tmp/dir con espacios/logs/frontend.log' -Append"`
- `pytest` *(errores por dependencias faltantes: dotenv, pandas, fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689f95d54b34833099db167700422138