### PR TITLE
Asegura creación del log en scripts de arranque

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Levanta API y frontend al mismo tiempo.
 `start.bat` ejecuta primero `stop.bat` para liberar los puertos `8000` y `5173`,
 valida que sigan libres y luego inicia backend y frontend en ventanas
 separadas con `cmd /k`. Toda la salida se muestra en consola y se agrega a
-`logs/server.log` con marca temporal. Tras unos segundos se realiza una
+`logs/server.log` con marca temporal, verificando que el archivo exista antes de cada arranque.
+Tras unos segundos se realiza una
 petición con `curl` para confirmar que respondan.
 
 Las versiones recientes de `start.bat` soportan rutas con espacios porque las

--- a/start.bat
+++ b/start.bat
@@ -62,6 +62,8 @@ if %errorlevel%==0 (
 ) else (
   call :log "[INFO] Iniciando backend..."
   start "Growen API" cmd /k "powershell -Command \"uvicorn services.api:app --reload 2^>^&1 ^| Tee-Object -FilePath '%LOG_FILE%' -Append\""
+  REM Verificación: crea el archivo de log si no existe para registrar la salida del backend
+  if not exist "%LOG_FILE%" echo > "%LOG_FILE%"
   timeout /t 5 /nobreak >nul
   curl --silent --fail http://localhost:8000/docs >nul 2>&1
   if %errorlevel%==0 (
@@ -91,6 +93,8 @@ if %errorlevel%==0 (
 ) else (
   call :log "[INFO] Iniciando frontend..."
   start "Growen Frontend" cmd /k "powershell -Command \"Set-Location -Path '%FRONTEND_DIR%'; npm run dev 2^>^&1 ^| Tee-Object -FilePath '%LOG_FILE%' -Append\""
+  REM Verificación: crea el archivo de log si no existe para registrar la salida del frontend
+  if not exist "%LOG_FILE%" echo > "%LOG_FILE%"
   timeout /t 5 /nobreak >nul
   curl --silent --fail http://localhost:5173/ >nul 2>&1
   if %errorlevel%==0 (


### PR DESCRIPTION
## Resumen
- Verificación adicional en `start.bat` para crear `logs/server.log` si falta tras iniciar backend y frontend.
- Documentación actualizada sobre la verificación del log en `start.bat`.

## Testing
- `pytest` *(falló: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_689f989d20308330a34756cbb8f9021a