### PR TITLE
feat: lanzadores CMD para Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,33 +74,25 @@ Levanta API y frontend al mismo tiempo.
 
 ### Windows
 
-- **CMD**: doble clic en `start.bat`.
-- **PowerShell**: `./start.ps1` (si `ExecutionPolicy` lo bloquea: `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`).
+Doble clic en `start.bat` → abre dos ventanas:
 
-`start.bat` ejecuta primero `stop.bat` para liberar los puertos `8000` y `5173`,
-valida que sigan libres y luego inicia backend y frontend en ventanas
-separadas con `cmd /k`. Toda la salida se muestra en consola y se agrega a
-`logs/server.log` con marca temporal, verificando que el archivo exista antes de cada arranque.
-Tras unos segundos se realiza una
-petición con `curl` para confirmar que respondan.
+- Growen API (Uvicorn) en http://127.0.0.1:8000/docs
+- Growen Frontend (Vite) en http://127.0.0.1:5173/
 
-Las versiones recientes de `start.bat` soportan rutas con espacios porque las
-envuelven en comillas simples al invocar PowerShell. Si aun así aparecen
-problemas, prueba con `start.ps1` o mueve el repositorio a una ruta sin
-espacios. El script utiliza PowerShell y un mal escape de comillas puede
-impedir el arranque.
+Requisitos previos:
 
-- **Backend**: `http://localhost:8000/docs`
-- **Frontend**: `http://localhost:5173/`
+- Python 3.11
+- venv creado e instalado (`python -m venv .venv` → activar → `pip install -e .`)
+- Node.js/npm instalados
+- `.env` completado (DB_URL, IA, etc.)
 
-En consola se muestran mensajes `[OK]` o `[ERROR]` según el estado y las
-ventanas permanecen abiertas incluso si ocurre un fallo. El resultado de cada
-inicio queda registrado en `logs/server.log` con entradas como
-`[YYYY-MM-DD HH:MM:SS] START backend: OK`.
+Para detener:
 
-Para detener los servicios usar `stop.bat` (CMD) o `stop.ps1` (PowerShell);
-ambos cierran los procesos en `8000` y `5173` y registran la acción en el
-mismo archivo de log.
+- Doble clic en `stop.bat` → libera puertos 8000/5173.
+
+Rutas con espacios soportadas (scripts usan `cd /d` y comillas).
+
+PowerShell no requerido (los scripts son CMD puro).
 
 ### Debian/Ubuntu
 

--- a/scripts/run_api.cmd
+++ b/scripts/run_api.cmd
@@ -1,0 +1,22 @@
+@echo off
+setlocal
+REM Ubicar raíz del repo (dos niveles arriba desde /scripts)
+set "ROOT=%~dp0.."
+cd /d "%ROOT%"
+
+if not exist ".\.venv\Scripts\activate.bat" (
+  echo [ERROR] No existe .venv\Scripts\activate.bat
+  echo Cree el venv: python -m venv .venv
+  echo Active: .\.venv\Scripts\activate.bat
+  echo Instale deps: pip install -e .
+  pause
+  exit /b 1
+)
+
+call ".\.venv\Scripts\activate.bat"
+echo [INFO] Lanzando backend (Uvicorn)...
+uvicorn services.api:app --reload
+
+echo [INFO] Backend finalizado.
+pause
+endlocal

--- a/scripts/run_frontend.cmd
+++ b/scripts/run_frontend.cmd
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+set "ROOT=%~dp0.."
+cd /d "%ROOT%\frontend"
+
+if not exist "package.json" (
+  echo [ERROR] No existe frontend\package.json
+  echo Verifique que la carpeta frontend este correcta.
+  dir /b
+  pause
+  exit /b 1
+)
+
+if not exist "node_modules" (
+  echo [INFO] Instalando dependencias del frontend...
+  npm install
+)
+
+echo [INFO] Lanzando frontend (Vite)...
+npm run dev
+
+echo [INFO] Frontend finalizado.
+pause
+endlocal

--- a/start.bat
+++ b/start.bat
@@ -1,117 +1,19 @@
 @echo off
-setlocal ENABLEDELAYEDEXPANSION
-set ERROR_FLAG=0
-
-REM ── Ir a la raíz del repo (ruta de este .bat)
+setlocal
 cd /d "%~dp0"
 
-REM ── Crear carpeta de logs y archivo
-if not exist "logs" mkdir logs
-set LOG_FILE=logs\server.log
+REM (Opcional) matar procesos viejos en 8000 y 5173
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do taskkill /PID %%a /F >NUL 2>&1
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do taskkill /PID %%a /F >NUL 2>&1
 
-REM ── Función para mostrar y registrar mensajes
-set LOG_TS=
-goto :skiplog
-:log
-for /f %%i in ('powershell -NoProfile -Command "Get-Date -Format \"yyyy-MM-dd HH:mm:ss\""') do set LOG_TS=%%i
-echo %~1
-echo [%LOG_TS%] %~1>> "%LOG_FILE%"
-exit /b
-:skiplog
+REM Lanzar procesos en ventanas separadas (sin PowerShell)
+start "Growen API" "%~dp0scripts\run_api.cmd"
+start "Growen Frontend" "%~dp0scripts\run_frontend.cmd"
 
-REM ── Verificar venv
-if not exist ".\.venv\Scripts\activate.bat" (
-  call :log "[WARN] No existe .venv. Cree el entorno primero: python -m venv .venv"
-  call :log "        Luego: .\.venv\Scripts\activate.bat && pip install -e ."
-  pause
-  goto :eof
-)
-
-REM ── Activar venv
-call ".\.venv\Scripts\activate.bat"
-
-REM ── Verificar .env y variables básicas
-if not exist ".env" (
-  call :log "[ERROR] Falta .env (copie .env.example a .env y complete DB_URL/IA)."
-  pause
-  goto :eof
-)
-
-for /f "usebackq tokens=1,2 delims==" %%A in (".env") do (
-  if /I "%%A"=="DB_URL" set DB_URL=%%B
-  if /I "%%A"=="OLLAMA_MODEL" set OLLAMA_MODEL=%%B
-)
-
-if "%DB_URL%"=="" (
-  call :log "[ERROR] Falta DB_URL en .env"
-  pause
-  goto :eof
-)
-if "%OLLAMA_MODEL%"=="" (
-  call :log "[WARN] Falta OLLAMA_MODEL en .env"
-)
-
-REM ── Detener servicios previos
-call stop.bat -q >nul 2>&1
-
-REM ── Iniciar backend si el puerto está libre
-netstat -ano | findstr ":8000" >nul
-if %errorlevel%==0 (
-  call :log "[ERROR] Puerto 8000 ocupado. No se inicia backend."
-  set ERROR_FLAG=1
-) else (
-  call :log "[INFO] Iniciando backend..."
-  start "Growen API" cmd /k "powershell -Command \"uvicorn services.api:app --reload 2^>^&1 ^| Tee-Object -FilePath '%LOG_FILE%' -Append\""
-  REM Verificación: crea el archivo de log si no existe para registrar la salida del backend
-  if not exist "%LOG_FILE%" echo > "%LOG_FILE%"
-  timeout /t 5 /nobreak >nul
-  curl --silent --fail http://localhost:8000/docs >nul 2>&1
-  if %errorlevel%==0 (
-    echo [OK] Backend en línea
-    call :log "START backend: OK"
-  ) else (
-    echo [ERROR] Backend no responde
-    call :log "START backend: ERROR"
-    set ERROR_FLAG=1
-  )
-)
-
-REM ── Frontend: instalar deps si faltan
-set FRONTEND_DIR=%~dp0frontend
-if not exist "%FRONTEND_DIR%\node_modules" (
-  call :log "[INFO] Instalando dependencias frontend..."
-  pushd "%FRONTEND_DIR%"
-  npm install
-  popd
-)
-
-REM ── Iniciar frontend si el puerto está libre
-netstat -ano | findstr ":5173" >nul
-if %errorlevel%==0 (
-  call :log "[ERROR] Puerto 5173 ocupado. No se inicia frontend."
-  set ERROR_FLAG=1
-) else (
-  call :log "[INFO] Iniciando frontend..."
-  start "Growen Frontend" cmd /k "powershell -Command \"Set-Location -Path '%FRONTEND_DIR%'; npm run dev 2^>^&1 ^| Tee-Object -FilePath '%LOG_FILE%' -Append\""
-  REM Verificación: crea el archivo de log si no existe para registrar la salida del frontend
-  if not exist "%LOG_FILE%" echo > "%LOG_FILE%"
-  timeout /t 5 /nobreak >nul
-  curl --silent --fail http://localhost:5173/ >nul 2>&1
-  if %errorlevel%==0 (
-    echo [OK] Frontend en línea
-    call :log "START frontend: OK"
-  ) else (
-    echo [ERROR] Frontend no responde
-    call :log "START frontend: ERROR"
-    set ERROR_FLAG=1
-  )
-)
-
-if %ERROR_FLAG%==1 (
-  echo.
-  echo [INFO] Ocurrieron errores.
-)
-
+echo.
+echo [INFO] Se lanzaron backend y frontend en ventanas separadas.
+echo [INFO] Backend:  http://127.0.0.1:8000/docs
+echo [INFO] Frontend: http://127.0.0.1:5173/
+echo.
 pause
-
-goto :eof
+endlocal

--- a/stop.bat
+++ b/stop.bat
@@ -1,16 +1,29 @@
 @echo off
 setlocal
+cd /d "%~dp0"
 
-REM ── Modo silencioso para uso desde start.bat
-if "%1"=="-q" set QUIET=1
+set "KILLCOUNT=0"
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do (
+  taskkill /PID %%a /F >NUL 2>&1
+  set /a KILLCOUNT+=1
+)
+if %KILLCOUNT% EQU 0 (
+  echo [INFO] No se encontro proceso en puerto 8000
+) else (
+  echo [INFO] Se cerraron %KILLCOUNT% proceso(s) del puerto 8000
+)
 
-if not exist logs mkdir logs
+set "KILLCOUNT=0"
+for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do (
+  taskkill /PID %%a /F >NUL 2>&1
+  set /a KILLCOUNT+=1
+)
+if %KILLCOUNT% EQU 0 (
+  echo [INFO] No se encontro proceso en puerto 5173
+) else (
+  echo [INFO] Se cerraron %KILLCOUNT% proceso(s) del puerto 5173
+)
 
-echo [%date% %time%] Cerrando backend (puerto 8000)... >> logs\server.log
-for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do taskkill /PID %%a /F
-
-echo [%date% %time%] Cerrando frontend (puerto 5173)... >> logs\server.log
-for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do taskkill /PID %%a /F
-
-if not defined QUIET pause
-
+echo Hecho.
+pause
+endlocal


### PR DESCRIPTION
## Resumen
- agregar scripts CMD para iniciar backend y frontend en ventanas separadas
- simplificar start.bat y stop.bat para uso sin PowerShell
- documentar inicio rápido en Windows con nuevos scripts

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689f9e8416d48330b370c4b35f4a6f95