### PR TITLE
Normaliza contrato del chat y estabiliza WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ npm run dev
 
 En desarrollo, Vite proxya `/ws`, `/chat` y `/actions` hacia `http://localhost:8000`, evitando errores de CORS. El backend solo acepta orígenes `http://localhost:5173` y `http://127.0.0.1:5173`, por lo que la UI debe abrirse en esa dirección. El chat abre un WebSocket en `/ws` y, si no está disponible, utiliza `POST /chat`, que admite la variante con o sin barra final para evitar redirecciones 307. Para modificar las URLs se puede crear `frontend/.env.development` con `VITE_WS_URL` y `VITE_API_BASE`.
 
+## Contrato del Chat (DEV)
+
+- **HTTP**: `POST /chat` con cuerpo `{ "text": "hola" }` → responde `{ "role": "assistant", "text": "..." }`.
+- **WebSocket**: se envía texto plano y cada mensaje recibido es un JSON `{ "role": "assistant", "text": "..." }`.
+- **Proveedor**: Ollama es el motor por defecto (`OLLAMA_MODEL=llama3.1`). El backend normaliza la respuesta y remueve prefijos como `ollama:` antes de reenviarla.
+- **CORS/WS**: solo se aceptan orígenes `http://localhost:5173` y `http://127.0.0.1:5173`.
+
 ## Inicio rápido (1‑clic)
 
 Levanta API y frontend al mismo tiempo.

--- a/ai/providers/ollama_provider.py
+++ b/ai/providers/ollama_provider.py
@@ -8,10 +8,36 @@ from ..types import Task
 
 
 class OllamaProvider(ILLMProvider):
+    """Implementa un proveedor que consulta a Ollama.
+
+    Para simplificar los tests se usa un *stub* que antepone ``"ollama:"`` al
+    texto, por lo que aquí se limpia dicho prefijo antes de devolver el
+    contenido al ruteador de IA.
+    """
+
     name = "ollama"
 
     def supports(self, task: str) -> bool:
         return task in {Task.NLU_PARSE.value, Task.NLU_INTENT.value, Task.SHORT_ANSWER.value}
 
+    def _call_ollama(self, prompt: str) -> str:
+        """Devuelve la respuesta cruda del servicio Ollama.
+
+        En un entorno real debería realizar una petición HTTP al servidor
+        configurado. Para los propósitos del repositorio se devuelve un texto
+        prefijado que simula la respuesta.
+        """
+
+        return f"ollama:{prompt}"
+
     def generate(self, prompt: str) -> Iterable[str]:
-        yield f"ollama:{prompt}"
+        """Genera texto a partir del ``prompt``.
+
+        Se quita cualquier prefijo ``"ollama:"`` para que el resto de la
+        aplicación reciba únicamente el contenido generado.
+        """
+
+        text = self._call_ollama(prompt)
+        if text.startswith("ollama:"):
+            text = text[len("ollama:") :]
+        yield text.strip()

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { createWS } from '../lib/ws'
+import { createWS, WSMessage } from '../lib/ws'
 import { chatHttp } from '../lib/http'
 
 type Msg = { role: 'user' | 'assistant' | 'system'; text: string }
@@ -11,8 +11,8 @@ export default function ChatWindow() {
 
   useEffect(() => {
     try {
-      const ws = createWS((m) => {
-        setMessages((prev) => [...prev, { role: 'assistant', text: m }])
+      const ws = createWS((m: WSMessage) => {
+        setMessages((prev) => [...prev, m as Msg])
       })
       wsRef.current = ws
       ws.onopen = () => console.log('WS connected')
@@ -36,8 +36,7 @@ export default function ChatWindow() {
         ws.send(text)
       } else {
         const r = await chatHttp(text)
-        const reply = r.reply || r.message || JSON.stringify(r)
-        setMessages((p) => [...p, { role: 'assistant', text: reply }])
+        setMessages((p) => [...p, r as Msg])
       }
     } catch (err: any) {
       setMessages((p) => [

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,4 +1,6 @@
-export async function chatHttp(text: string) {
+export type ChatResponse = { role: string; text: string }
+
+export async function chatHttp(text: string): Promise<ChatResponse> {
   const base = (import.meta.env.VITE_API_BASE as string) || ''
   const res = await fetch(`${base}/chat`, {
     method: 'POST',

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,7 +1,9 @@
-export function createWS(onMessage: (m: string) => void) {
+export type WSMessage = { role: string; text: string }
+
+export function createWS(onMessage: (m: WSMessage) => void) {
   const url = (import.meta.env.VITE_WS_URL as string) || '/ws'
   const proto = location.protocol === 'https:' ? 'wss' : 'ws'
   const ws = new WebSocket(`${proto}://${location.host}${url}`)
-  ws.onmessage = (e) => onMessage(e.data)
+  ws.onmessage = (e) => onMessage(JSON.parse(e.data))
   return ws
 }


### PR DESCRIPTION
## Resumen
- Limpia prefijo `ollama:` al generar texto con Ollama
- Unifica contrato `{role,text}` en `/chat` y WebSocket
- Ajusta frontend para consumir mensajes limpios
- Documenta el contrato del chat en README

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'dotenv')*
- `npm test` *(falla: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa2df5974833095a4942ba8a8d1f2