### PR TITLE
feat: gestionar dependencias desde scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ Levanta API y frontend al mismo tiempo.
 
 Doble clic en `start.bat` → abre dos ventanas:
 
+`start.bat` ejecuta previamente `fix_deps.bat` para asegurar que las dependencias de `pyproject.toml` estén instaladas en `.venv`.
+
 - Growen API (Uvicorn) en http://127.0.0.1:8000/docs
 - Growen Frontend (Vite) en http://127.0.0.1:5173/
 
 Requisitos previos:
 
 - Python 3.11
-- venv creado e instalado (`python -m venv .venv` → activar → `pip install -e .`)
+- venv creado (`python -m venv .venv`)
 - Node.js/npm instalados
 - `.env` completado (DB_URL, IA, etc.)
 

--- a/fix_deps.bat
+++ b/fix_deps.bat
@@ -1,0 +1,37 @@
+@echo off
+setlocal
+chcp 65001 >NUL
+cd /d "%~dp0"
+
+if not exist ".venv\Scripts\activate.bat" (
+  echo [ERROR] No existe .venv\Scripts\activate.bat
+  echo Cree el entorno: python -m venv .venv
+  pause
+  exit /b 1
+)
+
+call ".venv\Scripts\activate.bat"
+
+python "scripts\generate_requirements.py"
+if errorlevel 1 (
+  color 0C
+  echo [ERROR] No se pudo generar requirements.txt
+  color 07
+  pause
+  exit /b 1
+)
+
+pip install -r requirements.txt
+if errorlevel 1 (
+  color 0C
+  echo [ERROR] Falló la instalación de dependencias
+  color 07
+  pause
+  exit /b 1
+)
+
+color 0A
+echo [OK] Dependencias instaladas correctamente
+color 07
+pause
+exit /b 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+fastapi>=0.111.0
+uvicorn[standard]>=0.30.1
+sqlalchemy>=2.0.29
+alembic>=1.13.1
+psycopg[binary]>=3.1.18
+pydantic-settings>=2.2.1
+typer>=0.12.3
+websockets>=12.0
+pandas>=2.2.2
+openpyxl>=3.1.2
+
+# extras: dev
+ruff>=0.4.2
+black>=24.3.0
+pytest>=8.1.0
+python-dotenv>=1.0.0

--- a/scripts/generate_requirements.py
+++ b/scripts/generate_requirements.py
@@ -1,0 +1,31 @@
+import tomllib
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent
+pyproject = root / "pyproject.toml"
+req_file = root / "requirements.txt"
+
+project = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+
+base_deps = project.get("project", {}).get("dependencies", [])
+optional = project.get("project", {}).get("optional-dependencies", {})
+
+seen = set()
+lines = []
+for dep in base_deps:
+    if dep not in seen:
+        lines.append(dep)
+        seen.add(dep)
+for group, deps in optional.items():
+    lines.append("")
+    lines.append(f"# extras: {group}")
+    for dep in deps:
+        if dep not in seen:
+            lines.append(dep)
+            seen.add(dep)
+
+content = "\n".join(lines) + "\n"
+if req_file.exists() and req_file.read_text(encoding="utf-8") == content:
+    pass
+else:
+    req_file.write_text(content, encoding="utf-8")

--- a/start.bat
+++ b/start.bat
@@ -6,6 +6,14 @@ REM (Opcional) matar procesos viejos en 8000 y 5173
 for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":8000"') do taskkill /PID %%a /F >NUL 2>&1
 for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":5173"') do taskkill /PID %%a /F >NUL 2>&1
 
+call "%~dp0fix_deps.bat"
+if errorlevel 1 (
+  echo [ERROR] No se pudieron instalar las dependencias. Abortando.
+  pause
+  endlocal
+  exit /b 1
+)
+
 REM Lanzar procesos en ventanas separadas (sin PowerShell)
 start "Growen API" "%~dp0scripts\run_api.cmd"
 start "Growen Frontend" "%~dp0scripts\run_frontend.cmd"


### PR DESCRIPTION
## Resumen
- generar `requirements.txt` desde `pyproject.toml` incluyendo extras
- añadir `fix_deps.bat` para instalar dependencias en `.venv`
- ejecutar verificación de dependencias antes de iniciar servicios con `start.bat`

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_689fab18ba1c8330811b0d9558b8f046