### PR TITLE
feat: declarar httpx en dependencias

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Agente para gestión de catálogo y stock de Nice Grow con interfaz de chat web 
 - Node.js LTS
 - PostgreSQL 15
 - Opcional: Docker y Docker Compose
+- El backend usa httpx para llamadas a proveedores (Ollama / APIs); ya viene incluido.
 
 ## Instalación local
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "websockets>=12.0",
     "pandas>=2.2.2",
     "openpyxl>=3.1.2",
+    "httpx>=0.27,<0.28",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ typer>=0.12.3
 websockets>=12.0
 pandas>=2.2.2
 openpyxl>=3.1.2
+httpx>=0.27,<0.28
 
 # extras: dev
 ruff>=0.4.2


### PR DESCRIPTION
## Resumen
- declara httpx como dependencia principal del backend
- regenera requirements.txt con httpx y extras existentes
- documenta en README el uso de httpx para llamadas a proveedores

## Testing
- `pip install -r requirements.txt`
- `pytest` *(falla: connection refused a PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_689faeaed0b8833088109a521bf056eb