### PR TITLE
feat: agregar parser de Santa Planta

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,18 @@ La interfaz muestra las respuestas del asistente con la etiqueta visual **Growen
 
 ## Importación de listas de precios
 
-La API permite subir archivos de proveedores en formatos `.xlsx` o `.csv` para revisar y aplicar nuevas listas de precios.
+La API permite subir archivos de proveedores en formato `.xlsx` para revisar y aplicar nuevas listas de precios.
 
 1. `POST /suppliers/{supplier_id}/price-list/upload` recibe el archivo del proveedor y un parámetro `dry_run` (por defecto `true`). Es obligatorio que el proveedor exista y tenga un *parser* registrado.
 2. `GET /imports/{job_id}?limit=N` muestra las primeras `N` filas analizadas y los errores detectados (`N` por defecto es `50`).
 3. `POST /imports/{job_id}/commit` aplica los cambios, creando categorías, productos y relaciones en `supplier_products`.
 
 Cada proveedor tiene su propio formato de planilla. Los *parsers* disponibles se registran en `SUPPLIER_PARSERS`.
+Para depurar los parsers habilitados se puede llamar a `GET /debug/imports/parsers`.
 
 | Proveedor | Campos requeridos | Campos normalizados |
 |-----------|------------------|---------------------|
-| `santaplanta` | ID, Producto, Agrupamiento, Familia, SubFamilia, Compra Minima, PrecioDeCompra, PrecioDeVenta | codigo, nombre, categoria_path, compra_minima, precio_compra, precio_venta |
+| `santa-planta` | ID, Producto, PrecioDeCompra, PrecioDeVenta | codigo, nombre, categoria_path, compra_minima, precio_compra, precio_venta |
 
 En modo *dry-run* se puede revisar el contenido antes de confirmar los cambios definitivos.
 
@@ -107,7 +108,7 @@ En modo *dry-run* se puede revisar el contenido antes de confirmar los cambios d
 
 La interfaz de chat incluye un botón **+** y la opción de la botonera **Adjuntar Excel** para subir listas de precios sin pasar por la IA.
 
-1. Hacer clic en **Adjuntar Excel** o arrastrar un archivo `.xlsx`/`.csv` sobre la ventana.
+1. Hacer clic en **Adjuntar Excel** o arrastrar un archivo `.xlsx` sobre la ventana.
 2. El modal exige elegir un proveedor; si no existen proveedores se muestra un estado vacío con el botón **Crear proveedor**.
 3. Tras seleccionar proveedor y archivo, el frontend llama a `POST /suppliers/{supplier_id}/price-list/upload?dry_run=true`.
 4. Growen envía un mensaje de sistema con el `job_id` y abre un visor para revisar el *dry-run*.
@@ -164,7 +165,7 @@ Ejemplo de respuesta:
     {
       "product_id": 1,
       "name": "Carpa Indoor 80x80",
-      "supplier": {"id": 1, "slug": "santaplanta", "name": "Santa Planta"},
+      "supplier": {"id": 1, "slug": "santa-planta", "name": "Santa Planta"},
       "precio_compra": 10000.0,
       "precio_venta": 12500.0,
       "compra_minima": 1,

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -82,7 +82,7 @@ export default function UploadModal({ open, onClose, onUploaded, initialFile }: 
           </div>
         )}
         <div style={{ margin: '8px 0' }}>
-          <input type="file" accept=".xlsx,.csv" onChange={handleFile} />
+          <input type="file" accept=".xlsx" onChange={handleFile} />
         </div>
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 12 }}>
           <button onClick={onClose}>Cancelar</button>

--- a/frontend/src/services/imports.ts
+++ b/frontend/src/services/imports.ts
@@ -8,7 +8,14 @@ export async function uploadPriceList(supplierId: number, file: File): Promise<{
     body: fd,
     credentials: 'include',
   })
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`
+    try {
+      const data = await res.json()
+      if (data?.detail) msg = data.detail
+    } catch {}
+    throw new Error(msg)
+  }
   return res.json()
 }
 

--- a/services/routers/debug.py
+++ b/services/routers/debug.py
@@ -5,6 +5,8 @@ from db.session import engine
 import os
 from urllib.parse import urlsplit
 
+from services.suppliers.parsers import SUPPLIER_PARSERS
+
 router = APIRouter()
 
 
@@ -41,4 +43,10 @@ async def debug_config() -> dict[str, object]:
         "allowed_origins": [o.strip() for o in origins if o.strip()],
         "db_url": safe,
     }
+
+
+@router.get("/debug/imports/parsers")
+async def debug_import_parsers() -> dict[str, list[str]]:
+    """Lista los parsers de proveedores registrados."""
+    return {"parsers": list(SUPPLIER_PARSERS.keys())}
 

--- a/services/suppliers/parsers.py
+++ b/services/suppliers/parsers.py
@@ -1,59 +1,130 @@
 from __future__ import annotations
 
-from typing import List
-
+from typing import List, Tuple
+from io import BytesIO
 import pandas as pd
+import unicodedata
 
 
 class BaseSupplierParser:
     """Parser base para archivos de proveedores."""
 
     slug: str
-    required_columns: List[str]
 
-    def parse_df(self, df: pd.DataFrame) -> List[dict]:
-        """Normaliza el DataFrame a una lista de dicts homogéneos."""
+    def parse(self, content: bytes) -> Tuple[List[dict], dict]:
+        """Normaliza el contenido y devuelve filas y KPIs."""
         raise NotImplementedError
 
 
 class SantaPlantaParser(BaseSupplierParser):
     """Parser para planillas de Santa Planta."""
 
-    slug = "santaplanta"
-    required_columns = [
-        "ID",
-        "Producto",
+    slug = "santa-planta"
+    required_columns = ["ID", "Producto", "PrecioDeCompra", "PrecioDeVenta"]
+    optional_columns = [
         "Agrupamiento",
         "Familia",
         "SubFamilia",
         "Compra Minima",
-        "PrecioDeCompra",
-        "PrecioDeVenta",
+        "Stock",
     ]
+    _synonyms = {
+        "id": "ID",
+        "agrupamiento": "Agrupamiento",
+        "familia": "Familia",
+        "subfamilia": "SubFamilia",
+        "producto": "Producto",
+        "compraminima": "Compra Minima",
+        "stock": "Stock",
+        "preciodecompra": "PrecioDeCompra",
+        "preciocompra": "PrecioDeCompra",
+        "preciodeventa": "PrecioDeVenta",
+        "precioventa": "PrecioDeVenta",
+    }
 
-    def parse_df(self, df: pd.DataFrame) -> List[dict]:
+    def _norm_col(self, col: str) -> str:
+        base = unicodedata.normalize("NFKD", col)
+        base = "".join(ch for ch in base if not unicodedata.combining(ch))
+        return base.strip().lower().replace(" ", "")
+
+    def _rename_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        mapping = {c: self._synonyms.get(self._norm_col(c), c.strip()) for c in df.columns}
+        return df.rename(columns=mapping)
+
+    def parse(self, content: bytes) -> Tuple[List[dict], dict]:
+        try:
+            df = pd.read_excel(BytesIO(content), sheet_name="data")
+        except ValueError:
+            try:
+                sheets = pd.read_excel(BytesIO(content), sheet_name=None)
+            except Exception as e:  # noqa: BLE001
+                raise ValueError("Tipo de archivo no soportado") from e
+            df = None
+            for sheet in sheets.values():
+                sheet = self._rename_columns(sheet)
+                if all(col in sheet.columns for col in self.required_columns):
+                    df = sheet
+                    break
+            if df is None:
+                raise ValueError("Hoja 'data' no encontrada")
+        except Exception as e:  # noqa: BLE001
+            raise ValueError("Tipo de archivo no soportado") from e
+        else:
+            df = self._rename_columns(df)
+
         missing = [c for c in self.required_columns if c not in df.columns]
         if missing:
-            raise ValueError(f"Columnas faltantes: {missing}")
+            raise ValueError("Faltan columnas: " + ", ".join(missing))
 
         rows: List[dict] = []
+        errors = 0
         for _, row in df.iterrows():
-            parts = [
-                str(row.get("Agrupamiento", "")).strip(),
-                str(row.get("Familia", "")).strip(),
-                str(row.get("SubFamilia", "")).strip(),
-            ]
-            category_path = ">".join([p for p in parts if p])
-            data = {
-                "codigo": str(row["ID"]).strip(),
-                "nombre": str(row["Producto"]).strip(),
-                "categoria_path": category_path,
-                "compra_minima": int(row.get("Compra Minima") or 1),
-                "precio_compra": float(row.get("PrecioDeCompra") or 0),
-                "precio_venta": float(row.get("PrecioDeVenta") or 0),
-            }
-            rows.append(data)
-        return rows
+            code_raw = row.get("ID")
+            code = "" if pd.isna(code_raw) else str(code_raw).strip()
+            name_raw = row.get("Producto")
+            name = "" if pd.isna(name_raw) else str(name_raw).strip()
+            group = "" if pd.isna(row.get("Agrupamiento")) else str(row.get("Agrupamiento")).strip()
+            family = "" if pd.isna(row.get("Familia")) else str(row.get("Familia")).strip()
+            subfamily = "" if pd.isna(row.get("SubFamilia")) else str(row.get("SubFamilia")).strip()
+            parts = [p for p in [group, family, subfamily] if p]
+            category_path = ">".join(parts)
+            cm_raw = row.get("Compra Minima")
+            compra_minima = int(cm_raw) if not pd.isna(cm_raw) and str(cm_raw).strip() else 1
+            pc_raw = row.get("PrecioDeCompra")
+            pv_raw = row.get("PrecioDeVenta")
+            precio_compra = float(pc_raw) if not pd.isna(pc_raw) else 0.0
+            precio_venta = float(pv_raw) if not pd.isna(pv_raw) else 0.0
+
+            status = "ok"
+            error_msg = None
+            if not name:
+                status = "error"
+                error_msg = "nombre vacío"
+            elif not code:
+                status = "error"
+                error_msg = "codigo vacío"
+            elif precio_compra <= 0 or precio_venta <= 0:
+                status = "error"
+                error_msg = "precios inválidos"
+
+            if status == "error":
+                errors += 1
+
+            rows.append(
+                {
+                    "codigo": code,
+                    "nombre": name,
+                    "categoria_path": category_path,
+                    "compra_minima": compra_minima,
+                    "precio_compra": precio_compra,
+                    "precio_venta": precio_venta,
+                    "status": status,
+                    "error_msg": error_msg,
+                }
+            )
+
+        kpis = {"total": len(rows), "errors": errors}
+        return rows, kpis
 
 
 SUPPLIER_PARSERS = {


### PR DESCRIPTION
## Resumen
- agregar SantaPlantaParser con soporte de Excel y validaciones
- mejorar carga de listas con mensajes de error y kpis
- exponer `/debug/imports/parsers` y ajustar frontend para detallar errores

## Testing
- `ruff check services/suppliers/parsers.py services/routers/imports.py services/routers/debug.py tests/test_import_preview_limit.py`
- `pytest`
- `npm test` *(falla: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0870fe3d4833092df0552b09244f3