### PR TITLE
feat: canónicos y modo oscuro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@
 - Add: upload UI (+), dry-run viewer, commit
 - Add: productos canónicos y tabla de equivalencias
 - Add: middleware de logging, endpoints `/healthz` y `/debug/*`, SQLAlchemy con `echo` opcional.
+- Add: endpoints `GET/PATCH /canonical-products/{id}`, listado y borrado de `/equivalences`
+- Add: comparador de precios `GET /canonical-products/{id}/offers` con mejor precio marcado
+- Add: modo oscuro básico en el frontend

--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ La interfaz presenta una botonera fija sobre el chat con accesos rápidos:
 
 La barra queda visible al hacer scroll y usa un estilo mínimo con sombreado suave.
 
+## Modo oscuro
+
+El frontend define un esquema de color gris con acentos violeta (`#7C4DFF`) y verde (`#22C55E`).
+Un botón en la barra permite alternar el tema y, por defecto, se respeta `prefers-color-scheme` del sistema.
+
 ## Contrato del Chat (DEV)
 
 - **HTTP**: `POST /chat` con cuerpo `{ "text": "hola" }` → responde `{ "role": "assistant", "text": "..." }`.
@@ -88,6 +93,8 @@ La barra queda visible al hacer scroll y usa un estilo mínimo con sombreado sua
 La interfaz muestra las respuestas del asistente con la etiqueta visual **Growen**.
 
 ## Importación de listas de precios
+
+Flujo básico: **Subir Excel → Dry-run → Visor → Commit**.
 
 La API permite subir archivos de proveedores en formato `.xlsx` para revisar y aplicar nuevas listas de precios.
 
@@ -127,9 +134,12 @@ vincularse a uno de estos canónicos mediante *equivalencias*.
 
 - **Crear canónico**: `POST /canonical-products` con `name`, `brand` y `specs_json` opcional. El sistema genera `ng_sku` con el
   formato `NG-000001`.
-- **Listar canónicos**: `GET /canonical-products?q=` permite buscar y paginar el catálogo.
+- **Buscar canónicos**: `GET /canonical-products?q=&page=` permite paginar y filtrar.
+- **Detalle/edición**: `GET /canonical-products/{id}` y `PATCH /canonical-products/{id}` devuelven y actualizan un canónico.
 - **Vincular oferta**: `POST /equivalences` une un `supplier_product` existente con un `canonical_product`.
-- **Ver ofertas**: `GET /canonical-products/{id}/offers` muestra todas las ofertas vinculadas a un canónico para comparar precios.
+- **Listar equivalencias**: `GET /equivalences?supplier_id=&canonical_product_id=` soporta filtros y paginación.
+- **Eliminar equivalencia**: `DELETE /equivalences/{id}`.
+- **Comparador**: `GET /canonical-products/{id}/offers` ordena las ofertas por precio de venta y marca la mejor con `mejor_precio`.
 
 Variables de entorno relevantes:
 

--- a/frontend/src/components/AppToolbar.tsx
+++ b/frontend/src/components/AppToolbar.tsx
@@ -1,15 +1,21 @@
 export default function AppToolbar() {
+  function toggleTheme() {
+    const el = document.documentElement
+    el.dataset.theme = el.dataset.theme === 'dark' ? 'light' : 'dark'
+  }
+
   return (
     <div
       style={{
         position: 'sticky',
         top: 0,
-        background: '#fff',
+        background: 'var(--panel-bg)',
         padding: 8,
         display: 'flex',
         gap: 8,
         boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
         zIndex: 10,
+        color: 'var(--text-color)',
       }}
     >
       <button onClick={() => window.dispatchEvent(new Event('open-upload'))}>
@@ -21,6 +27,7 @@ export default function AppToolbar() {
       <button onClick={() => window.dispatchEvent(new Event('open-products'))}>
         Productos
       </button>
+      <button onClick={toggleTheme}>Modo oscuro</button>
     </div>
   )
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import "./styles.css";
+
+// Ajusta el tema inicial según `prefers-color-scheme`.
+const rootEl = document.documentElement;
+if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+  rootEl.dataset.theme = "dark";
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,4 +1,21 @@
+/* Variables de tema */
+:root {
+  --bg-color: #ffffff;
+  --panel-bg: #ffffff;
+  --text-color: #000000;
+  --primary-color: #7C4DFF;
+  --success-color: #22C55E;
+}
+
+[data-theme='dark'] {
+  --bg-color: #1f2937;
+  --panel-bg: #374151;
+  --text-color: #f3f4f6;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
 }

--- a/services/routers/canonical_products.py
+++ b/services/routers/canonical_products.py
@@ -1,10 +1,11 @@
 """Endpoints para productos canónicos y equivalencias."""
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from decimal import Decimal
 
 from db.models import (
     CanonicalProduct,
@@ -20,6 +21,12 @@ equivalences_router = APIRouter(prefix="/equivalences", tags=["catalog"])
 
 class CanonicalCreate(BaseModel):
     name: str
+    brand: str | None = None
+    specs_json: dict | None = None
+
+
+class CanonicalUpdate(BaseModel):
+    name: str | None = None
     brand: str | None = None
     specs_json: dict | None = None
 
@@ -79,12 +86,94 @@ async def list_canonical_products(
     }
 
 
+@canonical_router.get("/{canonical_id}")
+async def get_canonical_product(
+    canonical_id: int, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Obtiene un producto canónico por ``id``."""
+    cp = await session.get(CanonicalProduct, canonical_id)
+    if not cp:
+        raise HTTPException(status_code=404, detail="Canonical product not found")
+    return {
+        "id": cp.id,
+        "ng_sku": cp.ng_sku,
+        "name": cp.name,
+        "brand": cp.brand,
+        "specs_json": cp.specs_json,
+    }
+
+
+@canonical_router.patch("/{canonical_id}")
+async def update_canonical_product(
+    canonical_id: int,
+    req: CanonicalUpdate,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Actualiza un producto canónico."""
+    cp = await session.get(CanonicalProduct, canonical_id)
+    if not cp:
+        raise HTTPException(status_code=404, detail="Canonical product not found")
+    data = req.model_dump(exclude_unset=True)
+    for k, v in data.items():
+        setattr(cp, k, v)
+    await session.commit()
+    await session.refresh(cp)
+    return {
+        "id": cp.id,
+        "ng_sku": cp.ng_sku,
+        "name": cp.name,
+        "brand": cp.brand,
+        "specs_json": cp.specs_json,
+    }
+
+
 class EquivalenceCreate(BaseModel):
     supplier_id: int
     supplier_product_id: int
     canonical_product_id: int
     source: str = "manual"
     confidence: float | None = None
+
+
+@equivalences_router.get("")
+async def list_equivalences(
+    supplier_id: int | None = Query(default=None),
+    canonical_product_id: int | None = Query(default=None),
+    page: int = 1,
+    page_size: int = 20,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Lista equivalencias con filtros opcionales."""
+    stmt = select(ProductEquivalence)
+    if supplier_id is not None:
+        stmt = stmt.where(ProductEquivalence.supplier_id == supplier_id)
+    if canonical_product_id is not None:
+        stmt = stmt.where(
+            ProductEquivalence.canonical_product_id == canonical_product_id
+        )
+    total = await session.scalar(select(func.count()).select_from(stmt.subquery()))
+    result = await session.execute(
+        stmt.order_by(ProductEquivalence.id)
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    items = result.scalars().all()
+    return {
+        "page": page,
+        "page_size": page_size,
+        "total": total or 0,
+        "items": [
+            {
+                "id": eq.id,
+                "supplier_id": eq.supplier_id,
+                "supplier_product_id": eq.supplier_product_id,
+                "canonical_product_id": eq.canonical_product_id,
+                "source": eq.source,
+                "confidence": eq.confidence,
+            }
+            for eq in items
+        ],
+    }
 
 
 @equivalences_router.post("")
@@ -123,6 +212,19 @@ async def upsert_equivalence(
     }
 
 
+@equivalences_router.delete("/{equivalence_id}")
+async def delete_equivalence(
+    equivalence_id: int, session: AsyncSession = Depends(get_session)
+) -> dict:
+    """Elimina una equivalencia."""
+    eq = await session.get(ProductEquivalence, equivalence_id)
+    if not eq:
+        raise HTTPException(status_code=404, detail="Equivalence not found")
+    await session.delete(eq)
+    await session.commit()
+    return {"status": "deleted"}
+
+
 @canonical_router.get("/{canonical_id}/offers")
 async def list_offers(
     canonical_id: int, session: AsyncSession = Depends(get_session)
@@ -136,23 +238,39 @@ async def list_offers(
         )
         .join(Supplier, Supplier.id == SupplierProduct.supplier_id)
         .where(ProductEquivalence.canonical_product_id == canonical_id)
+        .order_by(SupplierProduct.current_sale_price)
     )
     result = await session.execute(stmt)
     rows = result.all()
-    return [
-        {
-            "supplier": {"id": sup.id, "name": sup.name, "slug": sup.slug},
-            "precio_venta": float(sp.current_sale_price)
+    best_price: Decimal | None = None
+    for sp, _ in rows:
+        if sp.current_sale_price is not None:
+            best_price = Decimal(sp.current_sale_price)
+            break
+    offers = []
+    for sp, sup in rows:
+        sale = (
+            Decimal(sp.current_sale_price).quantize(Decimal("0.01"))
             if sp.current_sale_price is not None
-            else None,
-            "precio_compra": float(sp.current_purchase_price)
+            else None
+        )
+        purchase = (
+            Decimal(sp.current_purchase_price).quantize(Decimal("0.01"))
             if sp.current_purchase_price is not None
-            else None,
-            "compra_minima": float(sp.min_purchase_qty)
-            if sp.min_purchase_qty is not None
-            else None,
-            "updated_at": sp.last_seen_at.isoformat() if sp.last_seen_at else None,
-            "supplier_product_id": sp.id,
-        }
-        for sp, sup in rows
-    ]
+            else None
+        )
+        offers.append(
+            {
+                "supplier": {"id": sup.id, "name": sup.name, "slug": sup.slug},
+                "precio_venta": float(sale) if sale is not None else None,
+                "precio_compra": float(purchase) if purchase is not None else None,
+                "compra_minima": float(sp.min_purchase_qty)
+                if sp.min_purchase_qty is not None
+                else None,
+                "updated_at": sp.last_seen_at.isoformat() if sp.last_seen_at else None,
+                "supplier_product_id": sp.id,
+                "mejor_precio":
+                    bool(sale is not None and best_price is not None and sale == best_price),
+            }
+        )
+    return offers


### PR DESCRIPTION
## Resumen
- agregar endpoints GET/PATCH para productos canónicos
- listado y eliminación de equivalencias
- comparador de precios con mejor oferta marcada
- modo oscuro básico con toggle y prefers-color-scheme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0919036f08330bc8a95b8e793e4e4