### PR TITLE
fix: migración idempotente para imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,16 @@ GRANT USAGE, CREATE ON SCHEMA public TO growen;
 
 ## Migraciones idempotentes
 
-Si hay tablas creadas previamente (manual u otras ramas), las migraciones no deben fallar; usamos inspección de esquema para crear/alterar según corresponda.
+Cuando existen tablas creadas manualmente o por otras ramas, las migraciones detectan el esquema real y agregan columnas, claves foráneas e índices faltantes en lugar de fallar con errores como `DuplicateTable` o `UndefinedColumn`. Esto vuelve a las migraciones seguras e idempotentes.
+
+Comandos útiles en `psql` para verificar el estado de una tabla:
+
+```sql
+\d supplier_price_history
+SELECT column_name FROM information_schema.columns
+  WHERE table_name='supplier_price_history'
+  ORDER BY ordinal_position;
+```
 
 ## Instalación Frontend
 


### PR DESCRIPTION
## Resumen
- vuelve idempotente la migración `20241103_imports_tables`
- documenta cómo verificar tablas preexistentes y por qué las migraciones usan inspección de esquema

## Testing
- `pytest` *(falla: ModuleNotFoundError: No module named 'aiosqlite')*
- `alembic -c alembic.ini upgrade head` *(falla: connection to server at "127.0.0.1" refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b79b5d2c8330a24f3b5f430b7b21