### PR TITLE
Ejecutar migraciones antes de levantar el servidor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ uvicorn services.api:app --reload
 
 ## Migraciones automáticas
 
-`start.bat` y `scripts/run_api.cmd` ejecutan `alembic upgrade head` antes de iniciar el servidor.
+`start.sh`, `start.bat` y `scripts/run_api.cmd` ejecutan `alembic upgrade head` con el intérprete del entorno virtual antes de iniciar el servidor.
+Si la migración falla, el proceso se detiene para evitar correr con un esquema desactualizado.
 De esta forma la base siempre está en el esquema más reciente sin comandos manuales.
 
 ### Permisos mínimos en esquema

--- a/start.sh
+++ b/start.sh
@@ -29,6 +29,11 @@ if [[ -z "${OLLAMA_MODEL:-}" ]]; then
 fi
 
 # Backend (background) y Frontend (foreground)
+echo "[INFO] Aplicando migraciones de base de datos..."
+if ! .venv/bin/python -m alembic upgrade head; then
+  echo "[ERROR] Falló la ejecución de migraciones. Abortando inicio."
+  exit 1
+fi
 ( uvicorn services.api:app --host 127.0.0.1 --port 8000 --reload --log-level debug --access-log ) &
 
 cd frontend


### PR DESCRIPTION
## Resumen
- Ejecutar `alembic upgrade head` en start.sh antes de lanzar Uvicorn
- Documentar migraciones automáticas y manejo de errores en README

## Pruebas
- `bash -n start.sh`
- `pytest` (falla: ModuleNotFoundError: No module named 'aiosqlite')

------
https://chatgpt.com/codex/tasks/task_e_68a0da1eea288330ac9e9670cdb8556a