### PR TITLE
docs: unificar variable de Ollama

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ TN_SHOP_ID=
 # AI Hybrid
 AI_MODE=auto            # auto | openai | ollama
 AI_ALLOW_EXTERNAL=true  # false => bloquea proveedores externos
-OLLAMA_HOST=http://localhost:11434
+OLLAMA_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.1
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4.1-mini

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ TN_SHOP_ID=
 # AI Hybrid
 AI_MODE=auto            # auto | openai | ollama
 AI_ALLOW_EXTERNAL=true  # false => bloquea proveedores externos
-OLLAMA_HOST=http://localhost:11434
+OLLAMA_URL=http://localhost:11434
 OLLAMA_MODEL=llama3.1
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4.1-mini

--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
 - `DB_URL`: URL de PostgreSQL (si la contraseña tiene caracteres reservados, encodéalos, ej.: `=` → `%3D`).
 - `AI_MODE`: `auto`, `openai` u `ollama`.
 - `AI_ALLOW_EXTERNAL`: si es `false`, solo se usa Ollama.
-- `OLLAMA_HOST`, `OLLAMA_MODEL` (por defecto `llama3.1`).
+- `OLLAMA_URL`: URL base de Ollama (por defecto `http://localhost:11434`).
+- `OLLAMA_MODEL`: modelo de Ollama (por defecto `llama3.1`).
 - `OPENAI_API_KEY`, `OPENAI_MODEL`.
 - `SECRET_KEY`: clave usada para firmar sesiones.
 - `SESSION_EXPIRE_MINUTES`: tiempo de expiración de la sesión.

--- a/services/ai/provider.py
+++ b/services/ai/provider.py
@@ -1,4 +1,8 @@
-"""Cliente de IA que se conecta a Ollama."""
+"""Cliente de IA que se conecta a Ollama.
+
+La URL del servicio se lee desde la variable de entorno ``OLLAMA_URL``,
+permitiendo apuntar a instancias remotas sin tocar el código.
+"""
 
 import json
 import os


### PR DESCRIPTION
## Resumen
- documentar uso de `OLLAMA_URL` en el cliente de IA
- reemplazar `OLLAMA_HOST` por `OLLAMA_URL` en los archivos de entorno y en la documentación

## Testing
- `python - <<'PY'
import importlib, os
os.environ['OLLAMA_URL'] = 'http://dummy:1234'
import services.ai.provider as p
print('OLLAMA_URL=', p.OLLAMA_URL)
PY`
- `python - <<'PY'
import os, asyncio
os.environ['OLLAMA_URL'] = 'http://dummy:1234'
from services.ai.provider import ai_reply
async def test():
    try:
        await ai_reply('hola')
    except Exception as e:
        print('excepcion:', e)
asyncio.run(test())
PY`
- `pytest` *(errores: tests/test_debug_endpoints.py, tests/test_import_preview_limit.py, tests/test_suppliers_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db0ddf6083309276bb6ae1b87e12