### PR TITLE
Personalizar chat WebSocket según sesión

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Un botón en la barra permite alternar el tema y, por defecto, se respeta `prefe
 
 - **HTTP**: `POST /chat` con cuerpo `{ "text": "hola" }` → responde `{ "role": "assistant", "text": "..." }`.
 - **WebSocket**: se envía texto plano y cada mensaje recibido es un JSON `{ "role": "assistant", "text": "..." }`.
+- **Sesión**: si la cookie `growen_session` está presente, el backend incluye el nombre y rol del usuario en el prompt para personalizar la respuesta de la IA.
 - **Proveedor**: Ollama es el motor por defecto (`OLLAMA_MODEL=llama3.1`). El backend intenta primero con `stream=False` y, si la API falla, cae a modo *streaming* acumulando las partes. En ambos casos normaliza la respuesta y remueve prefijos como `ollama:` antes de reenviarla.
 
 La interfaz muestra las respuestas del asistente con la etiqueta visual **Growen**.

--- a/tests/test_ws_chat.py
+++ b/tests/test_ws_chat.py
@@ -1,0 +1,79 @@
+import os
+import asyncio
+from datetime import datetime, timedelta
+
+# Configurar DB en memoria antes de importar la app
+os.environ["DB_URL"] = "sqlite+aiosqlite:///:memory:"
+
+from fastapi.testclient import TestClient
+
+from services.api import app
+from db.base import Base
+from db.session import engine, SessionLocal
+from db.models import User, Session as DBSess
+
+
+async def _init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+asyncio.get_event_loop().run_until_complete(_init_db())
+
+client = TestClient(app)
+
+
+def test_ws_without_session(monkeypatch) -> None:
+    """Debe responder aunque no haya sesión."""
+    client.cookies.clear()
+    called = {}
+
+    async def fake_ai(prompt: str) -> str:
+        called["prompt"] = prompt
+        return "ok"
+
+    monkeypatch.setattr("services.routers.ws.ai_reply", fake_ai)
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("hola")
+        data = ws.receive_json()
+
+    assert called["prompt"] == "hola"
+    assert data == {"role": "assistant", "text": "ok"}
+
+
+def test_ws_with_session(monkeypatch) -> None:
+    """Personaliza el prompt con el nombre y rol del usuario."""
+    client.cookies.clear()
+    called = {}
+
+    async def fake_ai(prompt: str) -> str:
+        called["prompt"] = prompt
+        return "ok"
+
+    monkeypatch.setattr("services.routers.ws.ai_reply", fake_ai)
+
+    async def _create_session() -> None:
+        async with SessionLocal() as db:
+            user = User(identifier="u1", password_hash="x", role="cliente", name="User Uno")
+            db.add(user)
+            await db.flush()
+            sess = DBSess(
+                id="sid1",
+                user_id=user.id,
+                role=user.role,
+                csrf_token="tok",
+                expires_at=datetime.utcnow() + timedelta(minutes=5),
+            )
+            db.add(sess)
+            await db.commit()
+
+    asyncio.get_event_loop().run_until_complete(_create_session())
+    client.cookies.set("growen_session", "sid1")
+
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("hola")
+        data = ws.receive_json()
+
+    assert "User Uno" in called["prompt"] and "cliente" in called["prompt"]
+    assert data == {"role": "assistant", "text": "ok"}


### PR DESCRIPTION
## Resumen
- Personalización del WebSocket de chat usando la sesión del usuario para contextualizar el prompt.
- Documentación del contrato de chat actualizada para mencionar la identificación por sesión.
- Pruebas que cubren el flujo con y sin sesión en el WebSocket.

## Testing
- `pytest tests/test_ws_chat.py -q`
- `pytest -q` *(falla: falta plugin async y un endpoint requiere auth)*

------
https://chatgpt.com/codex/tasks/task_e_68a0db3e50f08330a0475bd6801531f8