### PR TITLE
Manejo de errores en WebSocket y cliente de IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ El endpoint de chat y el WebSocket analizan cada mensaje para detectar comandos.
 1. Si el texto corresponde a un intent conocido, se ejecuta el handler asociado y se retorna una respuesta estructurada.
 2. Cuando el intent es desconocido, se invoca `AIRouter.run` con la tarea `Task.SHORT_ANSWER` para generar una contestación libre mediante IA.
 
-El WebSocket utiliza la misma lógica para cada mensaje entrante y cierra la conexión de forma limpia ante una desconexión del cliente.
+El WebSocket utiliza la misma lógica para cada mensaje entrante y, ante una desconexión del cliente (`WebSocketDisconnect`), Starlette cierra el canal automáticamente, por lo que el servidor no invoca `close()` manualmente.
 
 Cuando el proveedor de IA elegido no soporta la tarea solicitada, el ruteador registra una advertencia y cambia a **Ollama** como alternativa.
 

--- a/services/ai/provider.py
+++ b/services/ai/provider.py
@@ -6,11 +6,13 @@ permitiendo apuntar a instancias remotas sin tocar el código.
 
 import json
 import os
+import logging
 
 import httpx
 
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "llama3.1")
+logger = logging.getLogger(__name__)
 
 
 async def ai_reply(prompt: str) -> str:
@@ -47,7 +49,7 @@ async def ai_reply(prompt: str) -> str:
                         text_parts.append(obj.get("response") or "")
                     except json.JSONDecodeError:
                         # Ignorar líneas que no sean JSON válido.
-                        pass
+                        logger.warning("Línea JSON inválida ignorada: %s", line)
             text = "".join(text_parts).strip()
 
     if text.lower().startswith("ollama:"):

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+import logging
+
+import httpx
+
+from services.ai import provider
+
+
+class DummyStream:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_lines(self):
+        yield "no-json"
+        yield json.dumps({"response": "ok"})
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, *args, **kwargs):
+        raise httpx.HTTPError("fallo")
+
+    def stream(self, *args, **kwargs):
+        return DummyStream()
+
+
+def test_ai_reply_logs_invalid_json(monkeypatch, caplog):
+    monkeypatch.setattr("services.ai.provider.httpx.AsyncClient", DummyClient)
+    with caplog.at_level(logging.WARNING):
+        text = asyncio.get_event_loop().run_until_complete(provider.ai_reply("hola"))
+    assert text == "ok"
+    assert any(
+        "Línea JSON inválida" in record.message for record in caplog.records
+    )

--- a/tests/test_ws_logging.py
+++ b/tests/test_ws_logging.py
@@ -1,0 +1,30 @@
+import logging
+
+from test_ws_chat import client
+
+
+def test_ws_logs_disconnect(caplog):
+    """Registra advertencia cuando el cliente se desconecta."""
+    with caplog.at_level(logging.WARNING):
+        with client.websocket_connect("/ws") as ws:
+            ws.close()
+    assert any(
+        "Cliente desconectado" in record.message for record in caplog.records
+    )
+
+
+def test_ws_logs_ai_error(monkeypatch, caplog):
+    """Registra error y notifica al cliente."""
+    async def boom(prompt: str) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("services.routers.ws.ai_reply", boom)
+
+    with caplog.at_level(logging.ERROR):
+        with client.websocket_connect("/ws") as ws:
+            ws.send_text("hola")
+            data = ws.receive_json()
+    assert data == {"role": "system", "text": "error: boom"}
+    assert any(
+        "Error inesperado en ws_chat" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Resumen
- Registrar desconexiones y errores del WebSocket en el log y avisar al cliente solo si la conexión sigue abierta
- Anotar y documentar el cierre automático tras `WebSocketDisconnect`
- Advertir cuando la IA recibe líneas JSON inválidas durante el streaming
- Añadir pruebas que validan el logueo de errores en el WebSocket y en el cliente de IA

## Pruebas
- `pytest` *(falla: tests/test_import_preview_limit.py::test_preview_limit - assert 403 == 200)*


------
https://chatgpt.com/codex/tasks/task_e_68a0defe99d48330bf48b861f47eaa8e