### PR TITLE
feat: comparativa de precios por canónico

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ vincularse a uno de estos canónicos mediante *equivalencias*.
 - **Eliminar equivalencia**: `DELETE /equivalences/{id}`.
 - **Comparador**: `GET /canonical-products/{id}/offers` ordena las ofertas por precio de venta y marca la mejor con `mejor_precio`.
 
+## Comparativa de precios
+
+El endpoint `GET /canonical-products/{id}/offers` devuelve todas las ofertas vinculadas a un canónico ordenadas por precio, destacando el mejor con el campo `mejor_precio`. Desde la interfaz se accede a esta tabla desde el visor de importación y el panel de productos cuando el artículo tiene una equivalencia canónica.
+
 Variables de entorno relevantes:
 
 ```env

--- a/frontend/src/components/CanonicalOffers.tsx
+++ b/frontend/src/components/CanonicalOffers.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { CanonicalOffer, listOffersByCanonical } from '../services/canonical'
+
+interface Props {
+  canonicalId: number
+  onClose: () => void
+}
+
+export default function CanonicalOffers({ canonicalId, onClose }: Props) {
+  const [offers, setOffers] = useState<CanonicalOffer[]>([])
+
+  useEffect(() => {
+    listOffersByCanonical(canonicalId)
+      .then(setOffers)
+      .catch(() => {})
+  }, [canonicalId])
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div className="panel p-4" style={{ width: 600, maxHeight: '80%', overflow: 'auto' }}>
+        <button onClick={onClose} style={{ float: 'right' }}>
+          Cerrar
+        </button>
+        <h3>Comparativa de precios</h3>
+        <table className="table w-full">
+          <thead>
+            <tr>
+              <th>Proveedor</th>
+              <th>Compra</th>
+              <th>Venta</th>
+              <th>Fecha</th>
+            </tr>
+          </thead>
+          <tbody>
+            {offers.map((of, idx) => (
+              <tr key={idx} className={of.mejor_precio ? 'best-price' : ''}>
+                <td>{of.supplier.name}</td>
+                <td>{of.precio_compra ?? ''}</td>
+                <td>{of.precio_venta ?? ''}</td>
+                <td>{of.updated_at ? new Date(of.updated_at).toLocaleString() : ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ImportViewer.tsx
+++ b/frontend/src/components/ImportViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { commitImport, getImportPreview } from '../services/imports'
+import CanonicalOffers from './CanonicalOffers'
 
 interface Props {
   open: boolean
@@ -17,6 +18,7 @@ export default function ImportViewer({ open, jobId, summary, kpis, onClose }: Pr
   const [committing, setCommitting] = useState(false)
   const [error, setError] = useState('')
   const [localSummary, setLocalSummary] = useState(summary)
+  const [canonicalId, setCanonicalId] = useState<number | null>(null)
 
   useEffect(() => {
     if (!open) return
@@ -62,7 +64,18 @@ export default function ImportViewer({ open, jobId, summary, kpis, onClose }: Pr
         {loading ? (
           <div>Cargando...</div>
         ) : (
-          <pre style={{ maxHeight: 300, overflow: 'auto' }}>{JSON.stringify(items, null, 2)}</pre>
+          <div style={{ maxHeight: 300, overflow: 'auto' }}>
+            {items.map((it) => (
+              <div key={it.row_index} style={{ marginBottom: 8 }}>
+                <pre>{JSON.stringify(it, null, 2)}</pre>
+                {it.data?.canonical_product_id && (
+                  <button onClick={() => setCanonicalId(it.data.canonical_product_id)}>
+                    Comparar precios
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
         )}
         <div>
           <strong>Resumen:</strong>
@@ -86,6 +99,9 @@ export default function ImportViewer({ open, jobId, summary, kpis, onClose }: Pr
           </div>
         </div>
       </div>
+      {canonicalId && (
+        <CanonicalOffers canonicalId={canonicalId} onClose={() => setCanonicalId(null)} />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ProductsDrawer.tsx
+++ b/frontend/src/components/ProductsDrawer.tsx
@@ -7,6 +7,7 @@ import {
   updateStock,
 } from '../services/products'
 import PriceHistoryModal from './PriceHistoryModal'
+import CanonicalOffers from './CanonicalOffers'
 
 interface Props {
   open: boolean
@@ -25,6 +26,7 @@ export default function ProductsDrawer({ open, onClose }: Props) {
   const [editing, setEditing] = useState<number | null>(null)
   const [stockVal, setStockVal] = useState('')
   const [historyProduct, setHistoryProduct] = useState<number | null>(null)
+  const [canonicalId, setCanonicalId] = useState<number | null>(null)
 
   useEffect(() => {
     if (open) {
@@ -141,6 +143,7 @@ export default function ProductsDrawer({ open, onClose }: Props) {
             <th>Categoría</th>
             <th>Actualizado</th>
             <th>Historial</th>
+            <th>Comparativa</th>
           </tr>
         </thead>
         <tbody>
@@ -183,6 +186,13 @@ export default function ProductsDrawer({ open, onClose }: Props) {
                   Ver
                 </button>
               </td>
+              <td>
+                {it.canonical_product_id && (
+                  <button onClick={() => setCanonicalId(it.canonical_product_id)}>
+                    Ver
+                  </button>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
@@ -203,6 +213,9 @@ export default function ProductsDrawer({ open, onClose }: Props) {
           productId={historyProduct}
           onClose={() => setHistoryProduct(null)}
         />
+      )}
+      {canonicalId && (
+        <CanonicalOffers canonicalId={canonicalId} onClose={() => setCanonicalId(null)} />
       )}
     </div>
   )

--- a/frontend/src/services/canonical.ts
+++ b/frontend/src/services/canonical.ts
@@ -1,0 +1,22 @@
+export interface CanonicalOffer {
+  supplier: { id: number; name: string; slug: string }
+  precio_venta: number | null
+  precio_compra: number | null
+  compra_minima: number | null
+  updated_at: string | null
+  supplier_product_id: number
+  mejor_precio: boolean
+}
+
+const base = import.meta.env.VITE_API_URL as string
+
+export async function listOffersByCanonical(
+  canonicalId: number,
+): Promise<CanonicalOffer[]> {
+  const res = await fetch(
+    `${base}/canonical-products/${canonicalId}/offers`,
+    { credentials: 'include' },
+  )
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -5,7 +5,10 @@ const http = axios.create({
 });
 http.interceptors.request.use((cfg) => {
   const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
-  if (m) (cfg.headers ??= {})["X-CSRF-Token"] = decodeURIComponent(m[1]);
+  if (m) {
+    const headers = (cfg.headers ??= {} as any);
+    headers["X-CSRF-Token"] = decodeURIComponent(m[1]);
+  }
   return cfg;
 });
 export default http;

--- a/frontend/src/services/products.ts
+++ b/frontend/src/services/products.ts
@@ -16,6 +16,7 @@ export interface ProductItem {
   category_path: string
   stock: number
   updated_at: string | null
+  canonical_product_id: number | null
 }
 
 export interface ProductSearchResponse {

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -72,6 +72,11 @@ body {
   background: var(--table-row-hover);
 }
 
+.best-price {
+  color: var(--success);
+  font-weight: bold;
+}
+
 .btn-primary {
   background: var(--primary);
   color: #fff;


### PR DESCRIPTION
## Resumen
- añade servicio `listOffersByCanonical` para consultar ofertas de un producto canónico
- crea componente `CanonicalOffers` con tabla que resalta el mejor precio
- integra comparativa en visor de importación y panel de productos cuando existe equivalencia
- expone `canonical_product_id` en API de productos y adapta estilos para tema oscuro

## Testing
- `npm test` (falla: Missing script "test")
- `npm run build`
- `pytest` (errores durante la recolección)


------
https://chatgpt.com/codex/tasks/task_e_68a796d48e088330933d0fde17814c69