### PR TITLE
Mejoras en start.bat con chequeo de puertos y logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Runtime
 ENV=dev
 
+# Directorio donde se almacenan los logs de desarrollo
+LOG_DIR=logs
+
 # DB (usar PostgreSQL en dev y prod)
 # Si la password tiene caracteres reservados (p.ej. '='), usar URL-encoding.
 # '=' => %3D, ':' => %3A, '@' => %40

--- a/README.md
+++ b/README.md
@@ -282,12 +282,16 @@ Levanta API y frontend al mismo tiempo.
 
 ### Windows
 
-Doble clic en `start.bat` → primero llama a `scripts\stop.bat`, espera 2 s y luego abre dos ventanas:
+Ejecutar **desde CMD** con doble clic en `start.bat`. El script realiza estas etapas:
 
-`start.bat` ejecuta `scripts\fix_deps.bat` para crear la venv, instalar dependencias y dejar listo el frontend.
+1. Llama a `scripts\stop.bat` y espera hasta 5 s para liberar procesos anteriores.
+2. Verifica que los puertos **8000** y **5173** estén libres; si alguno está ocupado aborta con un mensaje.
+3. Ejecuta `scripts\fix_deps.bat` para crear la venv, instalar dependencias y preparar el frontend.
+4. Abre dos ventanas:
+   - Growen API (Uvicorn) en http://127.0.0.1:8000/docs
+   - Growen Frontend (Vite) en http://127.0.0.1:5173/
 
-- Growen API (Uvicorn) en http://127.0.0.1:8000/docs
-- Growen Frontend (Vite) en http://127.0.0.1:5173/
+La salida de ambos servicios se guarda en `logs/backend.log` y `logs/frontend.log` para facilitar el diagnóstico.
 
 Requisitos previos:
 
@@ -297,11 +301,9 @@ Requisitos previos:
 - `.env` completado (DB_URL, IA, etc.)
 - `frontend/.env` creado a partir de `frontend/.env.example` si se necesita ajustar `VITE_API_URL`.
 
-Para detener:
+Para detener manualmente los servicios, ejecutar `scripts\stop.bat` desde CMD; cierra los procesos de Uvicorn y Vite.
 
-- Doble clic en `scripts\stop.bat` → cierra procesos de Uvicorn y Vite.
-
-Rutas con espacios soportadas (scripts usan `cd /d` y comillas).
+Rutas con espacios soportadas (los scripts usan `cd /d` y comillas).
 
 PowerShell no requerido (los scripts son CMD puro).
 

--- a/start.bat
+++ b/start.bat
@@ -4,23 +4,36 @@ setlocal ENABLEDELAYEDEXPANSION
 set ROOT=%~dp0
 set SCRIPTS=%ROOT%scripts
 set VENV=%ROOT%.venv\Scripts
+if not defined LOG_DIR set LOG_DIR=%ROOT%logs
 
-REM Cerrar instancias previas
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+
+echo [INFO] Cerrando procesos previos...
 if exist "%SCRIPTS%\stop.bat" call "%SCRIPTS%\stop.bat"
-timeout /t 2 /nobreak >NUL
+timeout /t 5 /nobreak >NUL
 
-REM Fix deps
+echo [INFO] Verificando puertos 8000 y 5173...
+for %%P in (8000 5173) do (
+  netstat -ano | findstr :%%P >NUL
+  if !ERRORLEVEL! EQU 0 (
+    echo [ERROR] El puerto %%P esta en uso. Abortando.
+    pause
+    exit /b 1
+  )
+)
+
+echo [INFO] Instalando dependencias...
 call "%SCRIPTS%\fix_deps.bat"
-if %ERRORLEVEL% NEQ 0 (
+if !ERRORLEVEL! NEQ 0 (
   echo [ERROR] Fallo la instalacion de dependencias
   pause
   exit /b 1
 )
 
-REM Migraciones
+echo [INFO] Ejecutando migraciones...
 pushd "%ROOT%"
 call "%VENV%\python.exe" -m alembic upgrade head
-if %ERRORLEVEL% NEQ 0 (
+if !ERRORLEVEL! NEQ 0 (
   echo [ERROR] Fallo al aplicar migraciones
   popd
   pause
@@ -28,12 +41,12 @@ if %ERRORLEVEL% NEQ 0 (
 )
 popd
 
-REM Backend
-start "Growen API" cmd /k ""%VENV%\python.exe" -m uvicorn services.api:app --host 127.0.0.1 --port 8000"
+echo [INFO] Iniciando backend...
+start "Growen API" cmd /k "\"%VENV%\\python.exe\" -m uvicorn services.api:app --host 127.0.0.1 --port 8000 > \"%LOG_DIR%\\backend.log\" 2>&1"
 
-REM Frontend
+echo [INFO] Iniciando frontend...
 pushd "%ROOT%frontend"
-start "Growen Frontend" cmd /k "npm run dev"
+start "Growen Frontend" cmd /k "npm run dev > \"%LOG_DIR%\\frontend.log\" 2>&1"
 popd
 
 endlocal


### PR DESCRIPTION
## Resumen
- Verifica puertos 8000 y 5173 antes de iniciar servicios y aborta si están ocupados.
- Redirige la salida de API y frontend a archivos en `logs/` y permite configurar la carpeta con `LOG_DIR`.
- Documenta el uso de `start.bat`/`scripts\stop.bat` y la ubicación de logs en README.

## Pruebas
- `python3 -m pytest` (errores: No module named 'dotenv', 'httpx', 'fastapi', 'pandas')
- `npm test` (errores: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a799e2d8788330aaf5eeb09bcf742a