### PR TITLE
Verificar claves sensibles en arranque

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,13 +38,14 @@ LOG_LEVEL=INFO
 DEBUG_SQL=0
 
 # Auth y seguridad
-SECRET_KEY=QJkL5zlPwER_Wa3I1tqM8pD-aVJi8bMOF1I8S2KWk85_gE850DLoFFaZ1rmZdvqgvQFxel0lrmIDfIapCMzRuQ
+# SECRET_KEY y ADMIN_PASS deben sobrescribirse; la aplicación abortará si quedan en 'changeme'
+SECRET_KEY=changeme
 SESSION_EXPIRE_MINUTES=43200
 COOKIE_SECURE=false
 COOKIE_DOMAIN=
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 ADMIN_USER=admin
-ADMIN_PASS=supersegura
+ADMIN_PASS=changeme
 MAX_UPLOAD_MB=8
 AUTH_ENABLED=true
 PRODUCTS_PAGE_MAX=100

--- a/agent_core/config.py
+++ b/agent_core/config.py
@@ -20,10 +20,22 @@ class Settings:
     ai_mode: str = os.getenv("AI_MODE", "auto")
     ai_allow_external: bool = os.getenv("AI_ALLOW_EXTERNAL", "true").lower() == "true"
     secret_key: str = os.getenv("SECRET_KEY", "changeme")
+    admin_user: str = os.getenv("ADMIN_USER", "admin")
+    admin_pass: str = os.getenv("ADMIN_PASS", "changeme")
     session_expire_minutes: int = int(os.getenv("SESSION_EXPIRE_MINUTES", "43200"))
     auth_enabled: bool = os.getenv("AUTH_ENABLED", "false").lower() == "true"
     cookie_secure: bool = os.getenv("COOKIE_SECURE", "false").lower() == "true"
     cookie_domain: str | None = os.getenv("COOKIE_DOMAIN") or None
+
+    def __post_init__(self) -> None:
+        if self.secret_key == "changeme":
+            raise RuntimeError(
+                "SECRET_KEY debe sobrescribirse; no puede permanecer en 'changeme'"
+            )
+        if self.admin_pass == "changeme":
+            raise RuntimeError(
+                "ADMIN_PASS debe sobrescribirse; no puede permanecer en 'changeme'"
+            )
 
 
 settings = Settings()


### PR DESCRIPTION
## Resumen
- Obligar a reemplazar `SECRET_KEY` y `ADMIN_PASS` para evitar valores por defecto.
- Sembrar usuario admin desde variables de entorno y validar contraseña segura en migración.
- Documentar en README y `.env.example` el reemplazo obligatorio de credenciales.

## Testing
- `SECRET_KEY=testkey ADMIN_PASS=testpass pytest` *(falla: 11 tests fallidos, ver detalles en la salida)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a045e37c8330a01968cff14151c3