### PR TITLE
Forzar cookies seguras en producción

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ DEBUG_SQL=0
 # SECRET_KEY y ADMIN_PASS deben sobrescribirse; la aplicación abortará si quedan en 'changeme'
 SECRET_KEY=changeme
 SESSION_EXPIRE_MINUTES=43200
+# Se ignora en producción; allí siempre es true
 COOKIE_SECURE=false
 COOKIE_DOMAIN=
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ ADMIN_USER=admin
 ADMIN_PASS=changeme
 SESSION_EXPIRE_MINUTES=43200
 AUTH_ENABLED=true
+# se ignora en producción; allí siempre es true
 COOKIE_SECURE=false
 COOKIE_DOMAIN=
 ```
@@ -367,7 +368,7 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
   por defecto `changeme`, rotarse periódicamente y mantenerse fuera del
   control de versiones. El servidor se detiene si no se sobrescribe.
 - `SESSION_EXPIRE_MINUTES`: tiempo de expiración de la sesión.
-- `COOKIE_SECURE`: activa cookies seguras en producción (debe ser `true` en entornos productivos).
+- `COOKIE_SECURE`: activa cookies seguras; se ignora en producción donde siempre están habilitadas.
 - `ALLOWED_ORIGINS`: orígenes permitidos para CORS, separados por coma. Si se
   incluye `http://localhost` o `http://127.0.0.1` se habilita automáticamente su
   contraparte con el mismo puerto.

--- a/services/auth.py
+++ b/services/auth.py
@@ -44,7 +44,9 @@ async def set_session_cookies(resp: Response, sid: str, csrf: str) -> None:
     """Configura cookies de sesión y CSRF."""
 
     max_age = settings.session_expire_minutes * 60
-    secure = settings.cookie_secure or settings.env == "production"
+    secure = settings.cookie_secure
+    if settings.env == "production":
+        secure = True
     cookie_args = {
         "httponly": True,
         "samesite": "lax",


### PR DESCRIPTION
## Resumen
- Sobrescribir `secure=True` al fijar cookies de sesión en producción sin depender de `COOKIE_SECURE`.
- Documentar que `COOKIE_SECURE` se ignora en producción.

## Testing
- `ruff check services/auth.py`
- `pytest` *(falla: ImportError en tests/test_debug_endpoints.py y módulos relacionados)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aafd8e348330904bc580af2d74c2