### PR TITLE
Agregar reset de contraseña y edición en panel de usuarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ El login acepta **identificador** o email junto con la contraseña. Al ejecutar 
 - `GET /auth/users` lista usuarios (solo admin).
 - `POST /auth/users` crea usuarios (solo admin, requiere CSRF).
 - `PATCH /auth/users/{id}` actualiza usuarios (solo admin, requiere CSRF).
+- `POST /auth/users/{id}/reset-password` regenera la contraseña (solo admin, requiere CSRF).
 
 ### Roles y permisos
 


### PR DESCRIPTION
## Resumen
- permitir a administradores editar usuarios vía `PATCH /auth/users/{id}`
- añadir `POST /auth/users/{id}/reset-password` para generar nueva contraseña
- actualizar panel de administración con formularios de edición y acción de reseteo

## Testing
- `pytest` *(errores: assert 403 == 200 y funciones async no soportadas)*


------
https://chatgpt.com/codex/tasks/task_e_68a7b7bd8a588330b1a7aea3102b0e1d