### PR TITLE
docs: listar roles por endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ El login acepta **identificador** o email junto con la contraseña. Al ejecutar 
 | colaborador | Subir Excel y aplicar importaciones de cualquier proveedor |
 | admin       | Todos los permisos, incluyendo registrar usuarios |
 
+La lista completa de rutas y roles se encuentra en [docs/roles-endpoints.md](docs/roles-endpoints.md).
+
 ### Variables de entorno relevantes
 
 ```env

--- a/docs/roles-endpoints.md
+++ b/docs/roles-endpoints.md
@@ -1,0 +1,48 @@
+# Roles por endpoint
+
+Este documento enumera cada endpoint de la API con el método HTTP y los roles requeridos.
+Las rutas sin un rol específico son accesibles para cualquier usuario, incluido `guest`.
+
+| Método | Ruta | Roles requeridos |
+|--------|------|------------------|
+| GET | /health | Ninguno |
+| GET | /health/ai | Ninguno |
+| POST | /auth/login | Ninguno |
+| POST | /auth/guest | Ninguno |
+| POST | /auth/logout | Ninguno (requiere CSRF) |
+| GET | /auth/me | Ninguno |
+| GET | /auth/users | admin |
+| POST | /auth/users | admin (requiere CSRF) |
+| PATCH | /auth/users/{user_id} | admin (requiere CSRF) |
+| POST | /auth/users/{user_id}/reset-password | admin (requiere CSRF) |
+| GET | /suppliers | Ninguno |
+| GET | /suppliers/{supplier_id}/files | Ninguno |
+| POST | /suppliers | admin (requiere CSRF) |
+| PATCH | /suppliers/{supplier_id} | admin (requiere CSRF) |
+| GET | /categories | Ninguno |
+| GET | /categories/search | Ninguno |
+| POST | /categories/generate-from-supplier-file | admin (requiere CSRF) |
+| GET | /products | cliente, proveedor, colaborador, admin |
+| PATCH | /products/{product_id}/stock | manager, admin (requiere CSRF) |
+| GET | /price-history | cliente, proveedor, colaborador, admin |
+| POST | /canonical-products | admin (requiere CSRF) |
+| GET | /canonical-products | Ninguno |
+| GET | /canonical-products/{canonical_id} | Ninguno |
+| PATCH | /canonical-products/{canonical_id} | admin (requiere CSRF) |
+| GET | /equivalences | Ninguno |
+| POST | /equivalences | manager, admin (requiere CSRF) |
+| DELETE | /equivalences/{equivalence_id} | manager, admin (requiere CSRF) |
+| GET | /suppliers/{supplier_id}/price-list/template | Ninguno |
+| POST | /suppliers/{supplier_id}/price-list/upload | proveedor, colaborador, admin (requiere CSRF) |
+| GET | /imports/{job_id}/preview | Ninguno |
+| GET | /imports/{job_id} | Ninguno |
+| POST | /imports/{job_id}/commit | proveedor, colaborador, admin (requiere CSRF) |
+| GET | /actions/ | Ninguno |
+| POST | /chat | Ninguno |
+| WebSocket | /ws | Ninguno |
+| GET | /healthz* | admin |
+| GET | /debug/db* | admin |
+| GET | /debug/config* | admin |
+| GET | /debug/imports/parsers* | admin |
+
+Las rutas marcadas con * solo están disponibles cuando `ENV` es distinto de `production`.


### PR DESCRIPTION
## Resumen
- documentar el rol requerido para cada ruta
- enlazar lista de rutas desde el README

## Testing
- `SECRET_KEY=testing ADMIN_PASS=testing pytest` *(falla: assert 403 == 200 en varias pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9f01f508330bbcd896dd078faa3