### PR TITLE
Ajusta expiración de sesión por defecto a un día

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ DEBUG_SQL=0
 # Auth y seguridad
 # SECRET_KEY y ADMIN_PASS deben sobrescribirse; la aplicación abortará si quedan en 'changeme'
 SECRET_KEY=changeme
-SESSION_EXPIRE_MINUTES=43200
+SESSION_EXPIRE_MINUTES=1440  # duración de la sesión en minutos; 1440 = 1 día
 # Se ignora en producción; allí siempre es true
 COOKIE_SECURE=false
 COOKIE_DOMAIN=

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ La lista completa de rutas y roles se encuentra en [docs/roles-endpoints.md](doc
 SECRET_KEY=changeme
 ADMIN_USER=admin
 ADMIN_PASS=changeme
-SESSION_EXPIRE_MINUTES=43200
+SESSION_EXPIRE_MINUTES=1440 # 1 día
 AUTH_ENABLED=true
 # se ignora en producción; allí siempre es true
 COOKIE_SECURE=false
@@ -145,6 +145,12 @@ COOKIE_DOMAIN=
 iniciar la aplicación; ésta abortará el arranque si alguno permanece en
 `changeme`. Mantener estas claves fuera del control de versiones y rotarlas
 periódicamente.
+
+`SESSION_EXPIRE_MINUTES` define cuánto tiempo permanece válida una sesión.
+El valor sugerido de `1440` mantiene la sesión durante un día. Valores más
+altos reducen la frecuencia de inicio de sesión pero aumentan el riesgo en
+caso de robo de cookies; valores más bajos obligan a reautenticarse más seguido
+y elevan la seguridad.
 
 ## Botonera
 
@@ -370,7 +376,10 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
 - `SECRET_KEY`: clave usada para firmar sesiones; debe cambiarse del valor
   por defecto `changeme`, rotarse periódicamente y mantenerse fuera del
   control de versiones. El servidor se detiene si no se sobrescribe.
-- `SESSION_EXPIRE_MINUTES`: tiempo de expiración de la sesión.
+- `SESSION_EXPIRE_MINUTES`: tiempo de expiración de la sesión en minutos (por
+  defecto 1440 = 1 día). Incrementarlo prolonga las sesiones pero aumenta el
+  riesgo ante robo de cookies; reducirlo fuerza reautenticaciones más frecuentes
+  y eleva la seguridad.
 - `COOKIE_SECURE`: activa cookies seguras; se ignora en producción donde siempre están habilitadas.
 - `ALLOWED_ORIGINS`: orígenes permitidos para CORS, separados por coma. Si se
   incluye `http://localhost` o `http://127.0.0.1` se habilita automáticamente su

--- a/agent_core/config.py
+++ b/agent_core/config.py
@@ -1,4 +1,5 @@
 """Configuración central del agente."""
+
 from __future__ import annotations
 
 import os
@@ -22,7 +23,9 @@ class Settings:
     secret_key: str = os.getenv("SECRET_KEY", "changeme")
     admin_user: str = os.getenv("ADMIN_USER", "admin")
     admin_pass: str = os.getenv("ADMIN_PASS", "changeme")
-    session_expire_minutes: int = int(os.getenv("SESSION_EXPIRE_MINUTES", "43200"))
+    session_expire_minutes: int = int(
+        os.getenv("SESSION_EXPIRE_MINUTES", "1440")
+    )  # duración de la sesión en minutos (1 día por defecto)
     auth_enabled: bool = os.getenv("AUTH_ENABLED", "false").lower() == "true"
     cookie_secure: bool = os.getenv("COOKIE_SECURE", "false").lower() == "true"
     cookie_domain: str | None = os.getenv("COOKIE_DOMAIN") or None


### PR DESCRIPTION
## Resumen
- Establece `SESSION_EXPIRE_MINUTES` en 1440 minutos (1 día) como valor sugerido y actualiza la configuración para usarlo por defecto.
- Documenta el impacto de la expiración de sesión en `.env.example` y `README`.

## Pruebas
- `ruff check agent_core/config.py`
- `black agent_core/config.py`
- `SECRET_KEY=abc ADMIN_PASS=abc pytest` *(falla: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68a8bd1e28788330ab1c869c747daefa