### PR TITLE
feat: parser genérico configurable por YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ La API permite subir archivos de proveedores en formato `.xlsx` para revisar y a
 2. `GET /imports/{job_id}/preview?status=new,changed&page=1&page_size=50` lista las filas normalizadas filtradas por `status` y paginadas. La respuesta devuelve `{items, summary}` y permite inspeccionar también `status=error,duplicate_in_file` para los fallos.
 3. `POST /imports/{job_id}/commit` aplica los cambios, creando categorías, productos y relaciones en `supplier_products`.
 
-Cada proveedor tiene su propio formato de planilla. Los *parsers* disponibles se registran en `SUPPLIER_PARSERS`.
+Cada proveedor define su mapeo en `config/suppliers/*.yml`. Por cada archivo se genera automáticamente un `GenericExcelParser`.
+También pueden agregarse parsers especializados instalando paquetes que expongan un `entry_point` en el grupo `growen.suppliers.parsers`.
 Para depurar los parsers habilitados se puede llamar a `GET /debug/imports/parsers`, disponible solo para administradores y deshabilitado en producción.
 
-| Proveedor | Campos requeridos | Campos normalizados |
-|-----------|------------------|---------------------|
-| `santa-planta` | ID, Producto, PrecioDeCompra, PrecioDeVenta | codigo, nombre, categoria_path, compra_minima, precio_compra, precio_venta |
+| Proveedor | Configuración |
+|-----------|---------------|
+| `santa-planta` | `config/suppliers/santa-planta.yml` |
 
 En modo *dry-run* se puede revisar el contenido antes de confirmar los cambios definitivos.
 

--- a/config/suppliers/README.md
+++ b/config/suppliers/README.md
@@ -1,6 +1,7 @@
 # Mapeos de proveedores
 
-Cada archivo `.yml` describe cómo convertir las columnas de un archivo de un proveedor en los campos internos de Growen. Para crear uno nuevo, copie `default.yml` y ajuste los nombres de columnas y transformaciones.
+Cada archivo `.yml` describe cómo convertir las columnas de un archivo de un proveedor en los campos internos de Growen. El módulo `services.suppliers.parsers` genera un `GenericExcelParser` por cada YAML encontrado.
+Para crear uno nuevo, copie `default.yml` y ajuste los nombres de columnas y transformaciones. El nombre del archivo se usa como `slug` salvo que se defina explícitamente en el YAML.
 
 Campos principales:
 - `file_type`: `csv` o `xlsx`.


### PR DESCRIPTION
## Resumen
- agregar `GenericExcelParser` que lee mapeos desde `config/suppliers/*.yml`
- cargar parsers externos mediante `entry_points`
- documentar configuración y nuevos mecanismos de extensión

## Testing
- `SECRET_KEY=test ADMIN_PASS=test pytest` *(falla: `assert 403 == 200` en varios tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c06116f4833096a80c1e25def0d9