### PR TITLE
feat: plantilla genérica para listas de precios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@
 - Add: comparador de precios `GET /canonical-products/{id}/offers` con mejor precio marcado
 - Add: modo oscuro básico en el frontend
 - Add: plantilla Excel por proveedor `GET /suppliers/{id}/price-list/template`
+- Add: plantilla Excel genérica `GET /suppliers/price-list/template`
 - fix: restaurar migración `20241105_auth_roles_sessions` renombrando archivo y `revision` para mantener la cadena de dependencias
 - fix: evitar errores creando o borrando tablas ya existentes en `init_schema` mediante `sa.inspect`

--- a/README.md
+++ b/README.md
@@ -200,11 +200,12 @@ Las tablas `import_jobs` e `import_job_rows` guardan cada archivo cargado y sus 
 `supplier_price_history` registra los cambios de precios para auditoría.
 `GET /price-history` permite consultar ese historial filtrando por `supplier_product_id` o `product_id` y admite paginación. Solo está disponible para los roles `cliente`, `proveedor`, `colaborador` y `admin`.
 
-### Plantilla Excel por proveedor
+### Plantillas Excel
 
-`GET /suppliers/{supplier_id}/price-list/template` genera un archivo `.xlsx` con la hoja `data` y los encabezados esperados:
+`GET /suppliers/price-list/template` devuelve una plantilla genérica con la hoja `data` y los encabezados:
 `ID`, `Agrupamiento`, `Familia`, `SubFamilia`, `Producto`, `Compra Minima`, `Stock`, `PrecioDeCompra`, `PrecioDeVenta`.
-La celda `A1` incluye una nota con instrucciones y la fila 2 trae un ejemplo. Desde el modal de carga puede descargarse esta plantilla antes de completar los datos.
+`GET /suppliers/{supplier_id}/price-list/template` genera la misma estructura pero permite personalizar el nombre del archivo según el proveedor.
+La celda `A1` incluye una nota con instrucciones y la fila 2 trae un ejemplo. Desde el modal de carga pueden descargarse ambas variantes antes de completar los datos.
 
 ### Adjuntar Excel desde el chat
 

--- a/docs/roles-endpoints.md
+++ b/docs/roles-endpoints.md
@@ -32,6 +32,7 @@ Las rutas sin un rol específico son accesibles para cualquier usuario, incluido
 | GET | /equivalences | Ninguno |
 | POST | /equivalences | manager, admin (requiere CSRF) |
 | DELETE | /equivalences/{equivalence_id} | manager, admin (requiere CSRF) |
+| GET | /suppliers/price-list/template | Ninguno |
 | GET | /suppliers/{supplier_id}/price-list/template | Ninguno |
 | POST | /suppliers/{supplier_id}/price-list/upload | proveedor, colaborador, admin (requiere CSRF) |
 | GET | /imports/{job_id}/preview | Ninguno |

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react'
-import { uploadPriceList, downloadTemplate } from '../services/imports'
+import {
+  uploadPriceList,
+  downloadTemplate,
+  downloadGenericTemplate,
+} from '../services/imports'
 import { listSuppliers, Supplier } from '../services/suppliers'
 import CreateSupplierModal from './CreateSupplierModal'
 import { useAuth } from '../auth/AuthContext'
@@ -92,7 +96,12 @@ export default function UploadModal({ open, onClose, onUploaded, preselectedFile
         {suppliers.length === 0 ? (
           <div style={{ margin: '8px 0' }}>
             <p>No hay proveedores aún.</p>
-            <button onClick={() => setCreateOpen(true)}>Crear proveedor</button>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button onClick={() => setCreateOpen(true)}>Crear proveedor</button>
+              <button onClick={downloadGenericTemplate}>
+                Descargar plantilla genérica
+              </button>
+            </div>
           </div>
         ) : (
           <div style={{ margin: '8px 0' }}>
@@ -113,6 +122,9 @@ export default function UploadModal({ open, onClose, onUploaded, preselectedFile
               {state.role !== 'proveedor' && (
                 <button onClick={() => setCreateOpen(true)}>Crear proveedor</button>
               )}
+              <button onClick={downloadGenericTemplate}>
+                Descargar plantilla genérica
+              </button>
               <button
                 onClick={() => supplierId && downloadTemplate(Number(supplierId))}
                 disabled={!supplierId}

--- a/frontend/src/services/imports.ts
+++ b/frontend/src/services/imports.ts
@@ -42,6 +42,19 @@ export async function downloadTemplate(supplierId: number): Promise<void> {
   a.remove()
 }
 
+export async function downloadGenericTemplate(): Promise<void> {
+  const url = `${base}/suppliers/price-list/template`
+  const res = await fetch(url, { credentials: 'include' })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const blob = await res.blob()
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = `plantilla-generica.xlsx`
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}
+
 export async function commitImport(jobId: number): Promise<any> {
   const res = await http.post(`/imports/${jobId}/commit`)
   return res.data

--- a/services/routers/imports.py
+++ b/services/routers/imports.py
@@ -94,6 +94,43 @@ async def _upsert_supplier_product(
     await db.flush()
 
 
+@router.get("/suppliers/price-list/template")
+async def download_generic_price_list_template() -> StreamingResponse:
+    """Genera y descarga una plantilla Excel genérica para listas de precios."""
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "data"
+    headers = [
+        "ID",
+        "Agrupamiento",
+        "Familia",
+        "SubFamilia",
+        "Producto",
+        "Compra Minima",
+        "Stock",
+        "PrecioDeCompra",
+        "PrecioDeVenta",
+    ]
+    ws.append(headers)
+    ws.append(["123", "", "", "", "Ejemplo", 1, 0, 0.0, 0.0])
+    ws["A1"].comment = Comment(
+        "No borres la fila de encabezados. Completa tus productos desde la fila 2.",
+        "growen",
+    )
+
+    stream = BytesIO()
+    wb.save(stream)
+    stream.seek(0)
+    headers_resp = {
+        "Content-Disposition": 'attachment; filename="plantilla-generica.xlsx"'
+    }
+    return StreamingResponse(
+        stream,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers=headers_resp,
+    )
+
+
 @router.get("/suppliers/{supplier_id}/price-list/template")
 async def download_price_list_template(
     supplier_id: int, db: AsyncSession = Depends(get_session)

--- a/tests/test_download_generic_template.py
+++ b/tests/test_download_generic_template.py
@@ -1,0 +1,43 @@
+import os
+import asyncio
+from io import BytesIO
+
+from openpyxl import load_workbook
+from fastapi.testclient import TestClient
+
+os.environ["DB_URL"] = "sqlite+aiosqlite:///:memory:"
+
+from services.api import app  # noqa: E402
+from db.base import Base  # noqa: E402
+from db.session import engine  # noqa: E402
+
+
+async def _init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+asyncio.get_event_loop().run_until_complete(_init_db())
+
+client = TestClient(app)
+
+
+def test_download_generic_template() -> None:
+    resp = client.get("/suppliers/price-list/template")
+    assert resp.status_code == 200
+    assert "plantilla-generica.xlsx" in resp.headers.get("content-disposition", "")
+    wb = load_workbook(BytesIO(resp.content))
+    ws = wb.active
+    assert ws.title == "data"
+    headers = [
+        "ID",
+        "Agrupamiento",
+        "Familia",
+        "SubFamilia",
+        "Producto",
+        "Compra Minima",
+        "Stock",
+        "PrecioDeCompra",
+        "PrecioDeVenta",
+    ]
+    assert [cell.value for cell in ws[1]] == headers


### PR DESCRIPTION
## Resumen
- agrega endpoint `/suppliers/price-list/template` para descargar una plantilla Excel genérica
- incorpora botón **Descargar plantilla genérica** en el modal de subida y servicio asociado
- documenta nuevo endpoint y cubre descarga con prueba automática

## Testing
- `SECRET_KEY=test ADMIN_PASS=test pytest tests/test_download_generic_template.py`
- `SECRET_KEY=test ADMIN_PASS=test pytest` *(falla: 403 y async plugin no configurado)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c70ff94883308b600cff2a9eb46b