### PR TITLE
feat(frontend): virtualiza listado de productos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agente para gestión de catálogo y stock de Nice Grow con interfaz de chat web 
 - **Backend**: FastAPI + WebSocket.
 - **Base de datos**: PostgreSQL 15 (Alembic para migraciones).
 - **IA**: ruteo automático entre Ollama (local) y OpenAI.
-- **Frontend**: React + Vite.
+- **Frontend**: React + Vite con listas virtualizadas mediante `react-window`.
 - **Adapters**: stubs de Tiendanube.
 
 ## Requisitos

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,11 +11,13 @@
         "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.27.0"
+        "react-router-dom": "^6.27.0",
+        "react-window": "^1.8.11"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/react-window": "^1.8.8",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.5.4",
         "vite": "^5.3.3"
@@ -267,6 +269,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1123,6 +1134,16 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1617,6 +1638,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1778,6 +1805,23 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/rollup": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,17 +8,19 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 5173"
   },
-  "dependencies": {
-    "axios": "^1.7.7",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0"
-  },
-  "devDependencies": {
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "@vitejs/plugin-react": "^4.3.1",
-    "typescript": "^5.5.4",
-    "vite": "^5.3.3"
-  }
+    "dependencies": {
+      "axios": "^1.7.7",
+      "react": "^18.3.1",
+      "react-dom": "^18.3.1",
+      "react-router-dom": "^6.27.0",
+      "react-window": "^1.8.11"
+    },
+    "devDependencies": {
+      "@types/react": "^18.3.3",
+      "@types/react-dom": "^18.3.0",
+      "@types/react-window": "^1.8.8",
+      "@vitejs/plugin-react": "^4.3.1",
+      "typescript": "^5.5.4",
+      "vite": "^5.3.3"
+    }
 }

--- a/frontend/src/components/ProductsDrawer.tsx
+++ b/frontend/src/components/ProductsDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { FixedSizeList as List, ListChildComponentProps } from 'react-window'
 import { listSuppliers, Supplier } from '../services/suppliers'
 import { listCategories, Category } from '../services/categories'
 import {
@@ -27,6 +28,7 @@ export default function ProductsDrawer({ open, onClose }: Props) {
   const [stockVal, setStockVal] = useState('')
   const [historyProduct, setHistoryProduct] = useState<number | null>(null)
   const [canonicalId, setCanonicalId] = useState<number | null>(null)
+  const ROW_HEIGHT = 48
 
   useEffect(() => {
     if (open) {
@@ -132,7 +134,7 @@ export default function ProductsDrawer({ open, onClose }: Props) {
       <div style={{ fontSize: 12, marginBottom: 8 }}>
         {total} resultados
       </div>
-      <table className="table w-full">
+      <table className="table w-full" style={{ marginBottom: 0 }}>
         <thead>
           <tr>
             <th>Producto</th>
@@ -146,57 +148,77 @@ export default function ProductsDrawer({ open, onClose }: Props) {
             <th>Comparativa</th>
           </tr>
         </thead>
-        <tbody>
-          {items.map((it) => (
-            <tr key={it.product_id}>
-              <td>{it.name}</td>
-              <td>{it.supplier.name}</td>
-              <td>{it.precio_venta ?? ''}</td>
-              <td>{it.precio_compra ?? ''}</td>
-              <td>
-                {editing === it.product_id ? (
-                  <span>
-                    <input
-                      type="number"
-                      value={stockVal}
-                      onChange={(e) => setStockVal(e.target.value)}
-                      style={{ width: 60 }}
-                    />
-                    <button onClick={() => saveStock(it.product_id)}>Guardar</button>
-                  </span>
-                ) : (
-                  <span>
-                    {it.stock}
-                    <button
-                      onClick={() => {
-                        setEditing(it.product_id)
-                        setStockVal(String(it.stock))
-                      }}
-                      style={{ marginLeft: 4 }}
-                    >
-                      ✎
-                    </button>
-                  </span>
-                )}
-              </td>
-              <td>{it.category_path}</td>
-              <td>{it.updated_at ? new Date(it.updated_at).toLocaleString() : ''}</td>
-              <td>
-                <button onClick={() => setHistoryProduct(it.product_id)}>
-                  Ver
-                </button>
-              </td>
-              <td>
-                {it.canonical_product_id && (
-                  <button onClick={() => setCanonicalId(it.canonical_product_id)}>
-                    Ver
-                  </button>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
       </table>
+      <List
+        height={400}
+        itemCount={items.length}
+        itemSize={ROW_HEIGHT}
+        width={"100%"}
+      >
+        {({ index, style }: ListChildComponentProps) => {
+          const it = items[index]
+          return (
+            <table
+              key={it.product_id}
+              className="table w-full"
+              style={{ ...style, marginBottom: 0 }}
+            >
+              <tbody>
+                <tr>
+                  <td>{it.name}</td>
+                  <td>{it.supplier.name}</td>
+                  <td>{it.precio_venta ?? ''}</td>
+                  <td>{it.precio_compra ?? ''}</td>
+                  <td>
+                    {editing === it.product_id ? (
+                      <span>
+                        <input
+                          type="number"
+                          value={stockVal}
+                          onChange={(e) => setStockVal(e.target.value)}
+                          style={{ width: 60 }}
+                        />
+                        <button onClick={() => saveStock(it.product_id)}>Guardar</button>
+                      </span>
+                    ) : (
+                      <span>
+                        {it.stock}
+                        <button
+                          onClick={() => {
+                            setEditing(it.product_id)
+                            setStockVal(String(it.stock))
+                          }}
+                          style={{ marginLeft: 4 }}
+                        >
+                          ✎
+                        </button>
+                      </span>
+                    )}
+                  </td>
+                  <td>{it.category_path}</td>
+                  <td>
+                    {it.updated_at
+                      ? new Date(it.updated_at).toLocaleString()
+                      : ''}
+                  </td>
+                  <td>
+                    <button onClick={() => setHistoryProduct(it.product_id)}>
+                      Ver
+                    </button>
+                  </td>
+                  <td>
+                    {it.canonical_product_id && (
+                      <button onClick={() => setCanonicalId(it.canonical_product_id)}>
+                        Ver
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          )
+        }}
+      </List>
       <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
         <button disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
           Anterior


### PR DESCRIPTION
## Resumen
- usa `react-window` para renderizar filas de productos bajo demanda
- actualiza dependencias y documentación del frontend

## Testing
- `npm --prefix frontend test` (falla: Missing script "test")
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8c99491088330ba0996cdfd8f28e1