### PR TITLE
docs: documentar roles por endpoint

### DIFF
--- a/docs/roles-endpoints.md
+++ b/docs/roles-endpoints.md
@@ -29,6 +29,7 @@ Las rutas sin un rol específico son accesibles para cualquier usuario, incluido
 | GET | /canonical-products | Ninguno |
 | GET | /canonical-products/{canonical_id} | Ninguno |
 | PATCH | /canonical-products/{canonical_id} | admin (requiere CSRF) |
+| GET | /canonical-products/{canonical_id}/offers | Ninguno |
 | GET | /equivalences | Ninguno |
 | POST | /equivalences | manager, admin (requiere CSRF) |
 | DELETE | /equivalences/{equivalence_id} | manager, admin (requiere CSRF) |
@@ -41,6 +42,7 @@ Las rutas sin un rol específico son accesibles para cualquier usuario, incluido
 | GET | /actions/ | Ninguno |
 | POST | /chat | Ninguno |
 | WebSocket | /ws | Ninguno |
+| POST | /webhooks/tiendanube/ | Ninguno |
 | GET | /healthz* | admin |
 | GET | /debug/db* | admin |
 | GET | /debug/config* | admin |


### PR DESCRIPTION
## Resumen
- Detallar el rol requerido para cada ruta de la API.
- Incluir ofertas de productos canónicos y webhook de Tiendanube en la tabla.

## Testing
- `pytest` *(falla: SECRET_KEY debe sobrescribirse; no puede permanecer en 'changeme')*


------
https://chatgpt.com/codex/tasks/task_e_68a9c3dd9a68833091ccad13b983fc93