### PR TITLE
Documentar exportaciones de parsers de proveedores

### DIFF
--- a/config/suppliers/README.md
+++ b/config/suppliers/README.md
@@ -3,6 +3,11 @@
 Cada archivo `.yml` describe cómo convertir las columnas de un archivo de un proveedor en los campos internos de Growen. El módulo `services.suppliers.parsers` genera un `GenericExcelParser` por cada YAML encontrado.
 Para crear uno nuevo, copie `default.yml` y ajuste los nombres de columnas y transformaciones. El nombre del archivo se usa como `slug` salvo que se defina explícitamente en el YAML.
 
+Si se requiere un parser más complejo, pueden instalarse paquetes que
+exponan un `entry_point` en el grupo `growen.suppliers.parsers`. Las
+instancias detectadas se combinan automáticamente con las declaradas por
+YAML.
+
 Campos principales:
 - `file_type`: `csv` o `xlsx`.
 - `columns`: listas de posibles encabezados por campo interno.

--- a/services/suppliers/parsers.py
+++ b/services/suppliers/parsers.py
@@ -3,7 +3,8 @@
 Este módulo expone un parser genérico basado en archivos Excel/CSV
 configurable mediante archivos YAML ubicados en ``config/suppliers``.
 También permite agregar parsers personalizados a través de
-``entry_points`` del grupo ``growen.suppliers.parsers``.
+``entry_points`` del grupo ``growen.suppliers.parsers`` y expone
+``SUPPLIER_PARSERS`` con todas las instancias registradas.
 """
 
 from __future__ import annotations
@@ -16,6 +17,9 @@ from typing import Any, Dict
 
 import pandas as pd
 import yaml
+
+# objetos visibles al importar el módulo
+__all__ = ["BaseSupplierParser", "GenericExcelParser", "SUPPLIER_PARSERS"]
 
 
 class BaseSupplierParser:


### PR DESCRIPTION
## Resumen
- Explicita qué objetos expone el módulo de parsers e incorpora `SUPPLIER_PARSERS` en la documentación interna.
- Indica en la guía de mapeos cómo registrar parsers externos mediante `entry_points`.

## Pruebas
- `SECRET_KEY=tests ADMIN_PASS=tests pytest tests/test_download_generic_template.py::test_download_generic_template -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c752ec808330bafa216953c5d464