### PR TITLE
feat: mejorar visor de importaciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Flujo básico: **upload → preview → commit**.
 La API permite subir archivos de proveedores en formato `.xlsx` para revisar y aplicar nuevas listas de precios.
 
 1. `POST /suppliers/{supplier_id}/price-list/upload` recibe el archivo del proveedor (campo `file` en `multipart/form-data`) y un parámetro `dry_run` (por defecto `true`). Es obligatorio que el proveedor exista y tenga un *parser* registrado.
-2. `GET /imports/{job_id}/preview?status=new,changed&page=1&page_size=50` lista las filas normalizadas filtradas por `status` y paginadas. La respuesta devuelve `{items, summary, total, pages}` y permite inspeccionar también `status=error,duplicate_in_file` para los fallos.
+2. `GET /imports/{job_id}/preview?status=new,changed&page=1&page_size=50` lista las filas normalizadas filtradas por `status` y paginadas. La respuesta devuelve `{items, summary, total, pages, page}` y permite inspeccionar también `status=error,duplicate_in_file` para los fallos.
 3. `POST /imports/{job_id}/commit` aplica los cambios, creando categorías, productos y relaciones en `supplier_products`.
 
 Cada proveedor define su mapeo en `config/suppliers/*.yml`. Por cada archivo se genera automáticamente un `GenericExcelParser`.
@@ -214,7 +214,7 @@ La interfaz de chat incluye un botón **+** y la opción de la botonera **Adjunt
 1. Hacer clic en **Adjuntar Excel** o arrastrar un archivo `.xlsx` sobre la ventana.
 2. El modal exige elegir un proveedor; si no existen proveedores se muestra un estado vacío con el botón **Crear proveedor**.
 3. Tras seleccionar proveedor y archivo, el frontend llama a `POST /suppliers/{supplier_id}/price-list/upload?dry_run=true`.
-4. Growen envía un mensaje de sistema con el `job_id` y abre un visor que pagina las filas llamando a `GET /imports/{job_id}/preview`, mostrando el total de filas y el número de páginas devueltos por la API.
+4. Growen envía un mensaje de sistema con el `job_id` y abre un visor que pagina las filas llamando a `GET /imports/{job_id}/preview`, mostrando el total de filas, la página actual y el número de páginas devueltos por la API.
 5. El visor abre la pestaña **Cambios** por defecto para resaltar las variaciones y muestra el recuento en cada pestaña; desde allí se pueden filtrar errores y finalmente ejecutar `POST /imports/{job_id}/commit`.
 
 Errores comunes:

--- a/frontend/src/components/ImportViewer.tsx
+++ b/frontend/src/components/ImportViewer.tsx
@@ -30,6 +30,7 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
         setItems(r.items || [])
         setTotal(r.total || 0)
         setPages(r.pages || 1)
+        if (r.page && r.page !== page) setPage(r.page)
         if (r.summary) setLocalSummary(r.summary)
       })
       .catch((e) => setError(e.message))
@@ -58,11 +59,23 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
         {error && <div style={{ color: 'red' }}>{error}</div>}
         <div>
           <strong>KPIs:</strong>
-          <ul>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
             {Object.entries(localSummary || {}).map(([k, v]) => (
-              <li key={k}>{k}: {v as number}</li>
+              <div
+                key={k}
+                style={{
+                  background: '#f0f0f0',
+                  padding: '4px 8px',
+                  borderRadius: 4,
+                  minWidth: 80,
+                  textAlign: 'center',
+                }}
+              >
+                <div style={{ fontSize: 12 }}>{k}</div>
+                <div style={{ fontWeight: 'bold' }}>{v as number}</div>
+              </div>
             ))}
-          </ul>
+          </div>
         </div>
         <div style={{ margin: '8px 0', display: 'flex', gap: 8 }}>
           <button onClick={() => { setTab('changes'); setPage(1) }} disabled={tab === 'changes'}>

--- a/services/routers/imports.py
+++ b/services/routers/imports.py
@@ -338,6 +338,9 @@ async def preview_import(
             stmt = stmt.where(ImportJobRow.status.in_(statuses))
     count_stmt = select(func.count()).select_from(stmt.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
+    pages = (total + page_size - 1) // page_size
+    if pages and page > pages:
+        page = pages
 
     stmt = (
         stmt.order_by(ImportJobRow.row_index)
@@ -354,12 +357,12 @@ async def preview_import(
         }
         for r in res.scalars()
     ]
-    pages = (total + page_size - 1) // page_size
     return {
         "items": items,
         "summary": job.summary_json,
         "total": total,
         "pages": pages,
+        "page": page,
     }
 
 


### PR DESCRIPTION
## Summary
- agrega control de página y expone `page` en `/imports/{job_id}/preview`
- muestra KPIs en tarjetas y sincroniza paginación del visor
- documenta nuevo campo `page` y funcionamiento del visor

## Testing
- `pytest` *(falla: SECRET_KEY debe sobrescribirse)*
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9c8561cc08330a3b1a0b86f6bb344