### PR TITLE
docs: detallar descarga de plantilla genérica

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Las tablas `import_jobs` e `import_job_rows` guardan cada archivo cargado y sus 
 `GET /suppliers/price-list/template` devuelve una plantilla genérica con la hoja `data` y los encabezados:
 `ID`, `Agrupamiento`, `Familia`, `SubFamilia`, `Producto`, `Compra Minima`, `Stock`, `PrecioDeCompra`, `PrecioDeVenta`.
 `GET /suppliers/{supplier_id}/price-list/template` genera la misma estructura pero permite personalizar el nombre del archivo según el proveedor.
-La celda `A1` incluye una nota con instrucciones y la fila 2 trae un ejemplo. Desde el modal de carga pueden descargarse ambas variantes antes de completar los datos.
+La celda `A1` incluye una nota con instrucciones y la fila 2 trae un ejemplo. En el modal de carga hay un botón **Descargar plantilla genérica** que llama a `GET /suppliers/price-list/template` y otro **Descargar plantilla** que usa `GET /suppliers/{supplier_id}/price-list/template` para obtener el archivo específico antes de completar los datos.
 
 ### Adjuntar Excel desde el chat
 


### PR DESCRIPTION
## Resumen
- Documentar en el README los botones del modal de carga para descargar plantillas de lista de precios.

## Testing
- `SECRET_KEY=testing ADMIN_PASS=testing pytest tests/test_download_generic_template.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9cb27e8848330b948eecb4d944a48