### PR TITLE
feat(frontend): carga bajo demanda en listado de productos

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ La interfaz presenta una botonera fija sobre el chat con accesos rápidos:
 
 - **Adjuntar Excel** abre el modal de carga de listas de precios.
 - **Proveedores** muestra la gestión básica de proveedores (listar y crear).
-- **Productos** abre un panel para buscar en la base y ajustar stock manualmente.
+ - **Productos** abre un panel para buscar en la base y ajustar stock manualmente; los resultados se cargan bajo demanda al desplazarse gracias a `react-window`.
 
 La barra queda visible al hacer scroll y usa un estilo mínimo con sombreado suave.
 


### PR DESCRIPTION
## Resumen
- Virtualización del listado de productos con `react-window` y carga incremental al hacer scroll
- Limpieza automática de resultados al cambiar filtros
- Documentación actualizada sobre el funcionamiento del panel de productos

## Pruebas
- `npm test` *(falla: Missing script)*
- `npm run build`
- `pytest` *(falla: SECRET_KEY debe sobrescribirse)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cc0ead6c8330918ffbd62e51615e