### PR TITLE
Validar parametros de orden en catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Parámetros soportados:
 - `sort_by`: `updated_at`, `precio_venta`, `precio_compra` o `name`.
 - `order`: `asc` o `desc`.
 
+Si se envían otros valores en `sort_by` u `order`, la API responde `400 Bad Request`.
+
 Ejemplo de respuesta:
 
 ```json


### PR DESCRIPTION
## Resumen
- Se definen enumeraciones para los campos de ordenamiento y dirección en `/products`
- Se valida `sort_by` y `order` devolviendo 400 cuando los valores no son permitidos
- Se actualiza la documentación de la API para reflejar los nuevos errores 400

## Testing
- `pytest` (falla: SECRET_KEY debe sobrescribirse)


------
https://chatgpt.com/codex/tasks/task_e_68a9cd0e4b4483309104af73ed73ff8a