### PR TITLE
feat(frontend): formulario canónico y equivalencias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Add: plantilla Excel genérica `GET /suppliers/price-list/template`
 - fix: restaurar migración `20241105_auth_roles_sessions` renombrando archivo y `revision` para mantener la cadena de dependencias
 - fix: evitar errores creando o borrando tablas ya existentes en `init_schema` mediante `sa.inspect`
+- Add: componentes `CanonicalForm` y `EquivalenceLinker` integrados en `ImportViewer` y `ProductsDrawer`

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ La interfaz presenta una botonera fija sobre el chat con accesos rápidos:
 
 - **Adjuntar Excel** abre el modal de carga de listas de precios.
 - **Proveedores** muestra la gestión básica de proveedores (listar y crear).
- - **Productos** abre un panel para buscar en la base y ajustar stock manualmente; los resultados se cargan bajo demanda al desplazarse gracias a `react-window`.
+- **Productos** abre un panel para buscar en la base, ajustar stock y gestionar canónicos: permite editar fichas canónicas y vincular equivalencias manualmente. Los resultados se cargan bajo demanda al desplazarse gracias a `react-window`.
 
 La barra queda visible al hacer scroll y usa un estilo mínimo con sombreado suave.
 
@@ -183,7 +183,7 @@ Flujo básico: **upload → preview → commit**.
 La API permite subir archivos de proveedores en formato `.xlsx` para revisar y aplicar nuevas listas de precios.
 
 1. `POST /suppliers/{supplier_id}/price-list/upload` recibe el archivo del proveedor (campo `file` en `multipart/form-data`) y un parámetro `dry_run` (por defecto `true`). Es obligatorio que el proveedor exista y tenga un *parser* registrado.
-2. `GET /imports/{job_id}/preview?status=new,changed&page=1&page_size=50` lista las filas normalizadas filtradas por `status` y paginadas. La respuesta devuelve `{items, summary, total, pages, page}` y permite inspeccionar también `status=error,duplicate_in_file` para los fallos.
+2. `GET /imports/{job_id}/preview?status=new,changed&page=1&page_size=50` lista las filas normalizadas filtradas por `status` y paginadas. La respuesta devuelve `{items, summary, total, pages, page}` y permite inspeccionar también `status=error,duplicate_in_file` para los fallos. Durante esta vista previa es posible crear o editar productos canónicos y vincular equivalencias manualmente desde cada fila.
 3. `POST /imports/{job_id}/commit` aplica los cambios, creando categorías, productos y relaciones en `supplier_products`.
 
 Cada proveedor define su mapeo en `config/suppliers/*.yml`. Por cada archivo se genera automáticamente un `GenericExcelParser`.
@@ -226,6 +226,7 @@ Errores comunes:
 
 Para comparar precios entre proveedores se introduce un catálogo propio de productos canónicos. Cada oferta de un proveedor puede
 vincularse a uno de estos canónicos mediante *equivalencias*.
+El frontend ofrece los componentes **CanonicalForm** y **EquivalenceLinker** para crear o editar canónicos y asociar ofertas directamente desde la interfaz.
 
 - **Crear canónico**: `POST /canonical-products` con `name`, `brand` y `specs_json` opcional. El sistema genera `ng_sku` con el
   formato `NG-000001`.

--- a/frontend/src/components/CanonicalForm.tsx
+++ b/frontend/src/components/CanonicalForm.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import {
+  createCanonicalProduct,
+  getCanonicalProduct,
+  updateCanonicalProduct,
+  CanonicalProduct,
+} from '../services/canonical'
+
+interface Props {
+  canonicalId?: number
+  onClose: () => void
+  onSaved?: (cp: CanonicalProduct) => void
+}
+
+export default function CanonicalForm({ canonicalId, onClose, onSaved }: Props) {
+  const [name, setName] = useState('')
+  const [brand, setBrand] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (canonicalId) {
+      getCanonicalProduct(canonicalId)
+        .then((cp) => {
+          setName(cp.name)
+          setBrand(cp.brand || '')
+        })
+        .catch(() => {})
+    }
+  }, [canonicalId])
+
+  async function save() {
+    try {
+      setSaving(true)
+      let cp: CanonicalProduct
+      if (canonicalId) {
+        cp = await updateCanonicalProduct(canonicalId, {
+          name,
+          brand: brand || null,
+        })
+      } else {
+        cp = await createCanonicalProduct({
+          name,
+          brand: brand || null,
+        })
+      }
+      onSaved?.(cp)
+      onClose()
+    } catch (e: any) {
+      alert(e.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div className="panel p-4" style={{ width: 400 }}>
+        <h3>{canonicalId ? 'Editar canónico' : 'Nuevo canónico'}</h3>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <input
+            className="input"
+            placeholder="Nombre"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            className="input"
+            placeholder="Marca"
+            value={brand}
+            onChange={(e) => setBrand(e.target.value)}
+          />
+        </div>
+        <div style={{ marginTop: 12, textAlign: 'right' }}>
+          <button onClick={onClose} style={{ marginRight: 8 }}>
+            Cancelar
+          </button>
+          <button onClick={save} disabled={saving || !name}>
+            {saving ? 'Guardando...' : 'Guardar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/EquivalenceLinker.tsx
+++ b/frontend/src/components/EquivalenceLinker.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { upsertEquivalence } from '../services/equivalences'
+
+interface Props {
+  supplierId: number
+  supplierProductId: number
+  onClose: () => void
+}
+
+export default function EquivalenceLinker({
+  supplierId,
+  supplierProductId,
+  onClose,
+}: Props) {
+  const [canonicalId, setCanonicalId] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  async function save() {
+    const id = Number(canonicalId)
+    if (!id) return
+    try {
+      setSaving(true)
+      await upsertEquivalence({
+        supplier_id: supplierId,
+        supplier_product_id: supplierProductId,
+        canonical_product_id: id,
+      })
+      onClose()
+    } catch (e: any) {
+      alert(e.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div className="panel p-4" style={{ width: 320 }}>
+        <h3>Vincular equivalencia</h3>
+        <input
+          className="input w-full"
+          placeholder="ID canónico"
+          value={canonicalId}
+          onChange={(e) => setCanonicalId(e.target.value)}
+        />
+        <div style={{ marginTop: 12, textAlign: 'right' }}>
+          <button onClick={onClose} style={{ marginRight: 8 }}>
+            Cancelar
+          </button>
+          <button onClick={save} disabled={saving || !canonicalId}>
+            {saving ? 'Guardando...' : 'Guardar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ImportViewer.tsx
+++ b/frontend/src/components/ImportViewer.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { commitImport, getImportPreview } from '../services/imports'
 import CanonicalOffers from './CanonicalOffers'
+import CanonicalForm from './CanonicalForm'
+import EquivalenceLinker from './EquivalenceLinker'
 
 interface Props {
   open: boolean
@@ -20,6 +22,10 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
   const [error, setError] = useState('')
   const [localSummary, setLocalSummary] = useState(summary)
   const [canonicalId, setCanonicalId] = useState<number | null>(null)
+  const [editCanonicalId, setEditCanonicalId] = useState<number | null>(null)
+  const [equivData, setEquivData] = useState<
+    { supplierId: number; supplierProductId: number } | null
+  >(null)
 
   useEffect(() => {
     if (!open) return
@@ -92,11 +98,39 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
             {items.map((it) => (
               <div key={it.row_index} style={{ marginBottom: 8 }}>
                 <pre>{JSON.stringify(it, null, 2)}</pre>
-                {it.data?.canonical_product_id && (
-                  <button onClick={() => setCanonicalId(it.data.canonical_product_id)}>
-                    Comparar precios
-                  </button>
-                )}
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  {it.data?.canonical_product_id && (
+                    <>
+                      <button
+                        onClick={() => setCanonicalId(it.data.canonical_product_id)}
+                      >
+                        Comparar precios
+                      </button>
+                      <button
+                        onClick={() => setEditCanonicalId(it.data.canonical_product_id)}
+                      >
+                        Editar canónico
+                      </button>
+                    </>
+                  )}
+                  {!it.data?.canonical_product_id && (
+                    <button onClick={() => setEditCanonicalId(0)}>
+                      Nuevo canónico
+                    </button>
+                  )}
+                  {it.data?.supplier_id && it.data?.supplier_product_id && (
+                    <button
+                      onClick={() =>
+                        setEquivData({
+                          supplierId: it.data.supplier_id,
+                          supplierProductId: it.data.supplier_product_id,
+                        })
+                      }
+                    >
+                      Vincular equivalencia
+                    </button>
+                  )}
+                </div>
               </div>
             ))}
           </div>
@@ -124,6 +158,19 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
       </div>
       {canonicalId && (
         <CanonicalOffers canonicalId={canonicalId} onClose={() => setCanonicalId(null)} />
+      )}
+      {editCanonicalId !== null && (
+        <CanonicalForm
+          canonicalId={editCanonicalId || undefined}
+          onClose={() => setEditCanonicalId(null)}
+        />
+      )}
+      {equivData && (
+        <EquivalenceLinker
+          supplierId={equivData.supplierId}
+          supplierProductId={equivData.supplierProductId}
+          onClose={() => setEquivData(null)}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/ProductsDrawer.tsx
+++ b/frontend/src/components/ProductsDrawer.tsx
@@ -12,6 +12,8 @@ import {
 } from '../services/products'
 import PriceHistoryModal from './PriceHistoryModal'
 import CanonicalOffers from './CanonicalOffers'
+import CanonicalForm from './CanonicalForm'
+import EquivalenceLinker from './EquivalenceLinker'
 
 interface Props {
   open: boolean
@@ -32,6 +34,10 @@ export default function ProductsDrawer({ open, onClose }: Props) {
   const [stockVal, setStockVal] = useState('')
   const [historyProduct, setHistoryProduct] = useState<number | null>(null)
   const [canonicalId, setCanonicalId] = useState<number | null>(null)
+  const [editCanonicalId, setEditCanonicalId] = useState<number | null>(null)
+  const [equivData, setEquivData] = useState<
+    { supplierId: number; supplierProductId: number } | null
+  >(null)
   const ROW_HEIGHT = 48
 
   useEffect(() => {
@@ -154,6 +160,8 @@ export default function ProductsDrawer({ open, onClose }: Props) {
             <th>Categoría</th>
             <th>Actualizado</th>
             <th>Historial</th>
+            <th>Canónico</th>
+            <th>Equivalencia</th>
             <th>Comparativa</th>
           </tr>
         </thead>
@@ -225,6 +233,29 @@ export default function ProductsDrawer({ open, onClose }: Props) {
                     </button>
                   </td>
                   <td>
+                    {it.canonical_product_id ? (
+                      <button
+                        onClick={() => setEditCanonicalId(it.canonical_product_id)}
+                      >
+                        Editar
+                      </button>
+                    ) : (
+                      <button onClick={() => setEditCanonicalId(0)}>Nuevo</button>
+                    )}
+                  </td>
+                  <td>
+                    <button
+                      onClick={() =>
+                        setEquivData({
+                          supplierId: it.supplier.id,
+                          supplierProductId: it.product_id,
+                        })
+                      }
+                    >
+                      Vincular
+                    </button>
+                  </td>
+                  <td>
                     {it.canonical_product_id && (
                       <button onClick={() => setCanonicalId(it.canonical_product_id)}>
                         Ver
@@ -245,6 +276,19 @@ export default function ProductsDrawer({ open, onClose }: Props) {
       )}
       {canonicalId && (
         <CanonicalOffers canonicalId={canonicalId} onClose={() => setCanonicalId(null)} />
+      )}
+      {editCanonicalId !== null && (
+        <CanonicalForm
+          canonicalId={editCanonicalId || undefined}
+          onClose={() => setEditCanonicalId(null)}
+        />
+      )}
+      {equivData && (
+        <EquivalenceLinker
+          supplierId={equivData.supplierId}
+          supplierProductId={equivData.supplierProductId}
+          onClose={() => setEquivData(null)}
+        />
       )}
     </div>
   )

--- a/frontend/src/services/canonical.ts
+++ b/frontend/src/services/canonical.ts
@@ -1,3 +1,5 @@
+import http from './http'
+
 export interface CanonicalOffer {
   supplier: { id: number; name: string; slug: string }
   precio_venta: number | null
@@ -8,7 +10,40 @@ export interface CanonicalOffer {
   mejor_precio: boolean
 }
 
+export interface CanonicalProduct {
+  id: number
+  ng_sku: string
+  name: string
+  brand: string | null
+  specs_json: Record<string, any> | null
+}
+
 const base = import.meta.env.VITE_API_URL as string
+
+export async function getCanonicalProduct(
+  id: number,
+): Promise<CanonicalProduct> {
+  const res = await fetch(`${base}/canonical-products/${id}`, {
+    credentials: 'include',
+  })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+export async function createCanonicalProduct(
+  data: { name: string; brand?: string | null; specs_json?: any | null },
+): Promise<CanonicalProduct> {
+  const res = await http.post('/canonical-products', data)
+  return res.data
+}
+
+export async function updateCanonicalProduct(
+  id: number,
+  data: { name?: string; brand?: string | null; specs_json?: any | null },
+): Promise<CanonicalProduct> {
+  const res = await http.patch(`/canonical-products/${id}`, data)
+  return res.data
+}
 
 export async function listOffersByCanonical(
   canonicalId: number,

--- a/frontend/src/services/equivalences.ts
+++ b/frontend/src/services/equivalences.ts
@@ -1,0 +1,17 @@
+import http from './http'
+
+export interface EquivalenceRequest {
+  supplier_id: number
+  supplier_product_id: number
+  canonical_product_id: number
+  source?: string
+  confidence?: number | null
+}
+
+export async function upsertEquivalence(req: EquivalenceRequest): Promise<any> {
+  const res = await http.post('/equivalences', {
+    ...req,
+    source: req.source ?? 'manual',
+  })
+  return res.data
+}


### PR DESCRIPTION
## Resumen
- agregar componentes CanonicalForm y EquivalenceLinker para editar canónicos y vincular ofertas
- integrar gestión de canónicos y equivalencias en ImportViewer y ProductsDrawer
- documentar nuevas capacidades en README y CHANGELOG

## Testing
- `npm run build`
- `pytest` *(falla: SECRET_KEY debe sobrescribirse)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ce1549908330ae8fc4d91c602658