### PR TITLE
feat: agregar parser de opciones y nuevos handlers de intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ En el chat o vía API se pueden usar:
 - `/sync pull --dry-run`
 - `/sync push --dry-run`
 - `/stock adjust --sku=SKU --qty=5`
+- `/import last --apply`
+- `/search maceta`
 
 La ruta `GET /actions` devuelve acciones rápidas.
 

--- a/frontend/src/lib/commands.ts
+++ b/frontend/src/lib/commands.ts
@@ -1,5 +1,7 @@
 export const examples = [
   '/help',
   '/sync pull --dry-run',
-  '/stock adjust --sku=SKU123 --qty=1'
+  '/stock adjust --sku=SKU123 --qty=1',
+  '/import last --apply',
+  '/search maceta'
 ]

--- a/services/intents/handlers.py
+++ b/services/intents/handlers.py
@@ -1,12 +1,59 @@
 """Handlers de intents de ejemplo."""
-from typing import Dict
+from typing import Any, Dict, List
 
 
-def handle_help() -> Dict[str, str]:
+
+def handle_help(args: List[str], opts: Dict[str, Any]) -> Dict[str, str]:
     """Devuelve texto de ayuda simple."""
     return {
         "message": (
             "Comandos disponibles: /help, /sync pull, /sync push, "
-            "/stock adjust, /stock min"
+            "/stock adjust, /stock min, /import <archivo> --supplier=SLUG, "
+            "/search <texto>"
         )
     }
+
+
+def handle_stock(args: List[str], opts: Dict[str, Any]) -> Dict[str, Any]:
+    """Ejecuta operaciones de stock básicas."""
+    if not args:
+        return {"message": "Acción requerida: adjust|min"}
+    action = args[0]
+    sku = opts.get("sku")
+    qty = opts.get("qty")
+    if action == "adjust":
+        return {
+            "message": f"Stock ajustado para {sku} en {qty}",
+            "action": "adjust",
+            "sku": sku,
+            "qty": int(qty) if isinstance(qty, str) and qty.isdigit() else qty,
+        }
+    if action == "min":
+        return {
+            "message": f"Stock mínimo de {sku} en {qty}",
+            "action": "min",
+            "sku": sku,
+            "min": int(qty) if isinstance(qty, str) and qty.isdigit() else qty,
+        }
+    return {"message": f"Acción desconocida: {action}"}
+
+
+def handle_import(args: List[str], opts: Dict[str, Any]) -> Dict[str, Any]:
+    """Simula la importación de archivos de proveedores."""
+    if not args:
+        return {"message": "Falta archivo a importar"}
+    filename = args[0]
+    supplier = opts.get("supplier")
+    dry_run = bool(opts.get("dry_run") or opts.get("dry-run"))
+    return {
+        "message": f"Importando {filename} (supplier={supplier}, dry_run={dry_run})",
+        "file": filename,
+        "supplier": supplier,
+        "dry_run": dry_run,
+    }
+
+
+def handle_search(args: List[str], opts: Dict[str, Any]) -> Dict[str, Any]:
+    """Busca productos por texto o SKU."""
+    query = " ".join(args) or opts.get("q", "")
+    return {"message": f"Buscando '{query}'", "query": query}


### PR DESCRIPTION
## Resumen
- agregar parser simplificado de opciones estilo argparse
- manejar intents de stock, import y búsqueda
- documentar comandos disponibles y ejemplos

## Testing
- `SECRET_KEY=test ADMIN_PASS=123 ADMIN_USER=admin pytest` *(fallan: assert 403 == 200; async def no soportado)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d0d64c408330abcfbdebdbdad419