### PR TITLE
docs: unificar fuente de usuario inicial

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ LOG_LEVEL=INFO
 DEBUG_SQL=0
 
 # Auth y seguridad
-# SECRET_KEY y ADMIN_PASS deben sobrescribirse; la aplicación abortará si quedan en 'changeme'
+# SECRET_KEY, ADMIN_USER y ADMIN_PASS deben sobrescribirse; la aplicación abortará si SECRET_KEY o ADMIN_PASS quedan en 'changeme'
 SECRET_KEY=changeme
 # Duración de la sesión en minutos.
 # El valor sugerido de 1440 (1 día) equilibra seguridad y comodidad:
@@ -49,6 +49,7 @@ SESSION_EXPIRE_MINUTES=1440
 COOKIE_SECURE=false
 COOKIE_DOMAIN=
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+# Usuario administrador inicial; si no existe, se crea al ejecutar migraciones
 ADMIN_USER=admin
 ADMIN_PASS=changeme
 MAX_UPLOAD_MB=8

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e .[dev]
 cp .env.example .env
-# reemplazar SECRET_KEY y ADMIN_PASS antes de continuar
+# reemplazar SECRET_KEY, ADMIN_USER y ADMIN_PASS antes de continuar
 # las variables de entorno se cargan automáticamente desde .env
 # crear base de datos growen en PostgreSQL
 alembic -c ./alembic.ini upgrade head
@@ -103,7 +103,7 @@ En desarrollo, Vite proxya `/ws`, `/chat` y `/actions` hacia `http://localhost:8
 
 La API implementa sesiones mediante la cookie `growen_session` y un token CSRF almacenado en `csrf_token`. Cada vez que se inicia o cierra sesión se generan nuevos valores para ambas cookies, evitando la fijación de sesiones. Todas las mutaciones deben enviar el encabezado `X-CSRF-Token` coincidiendo con dicha cookie. Las rutas que modifican datos añaden dependencias `require_roles` para comprobar que el usuario posea el rol autorizado.
 
-El login acepta **identificador** o email junto con la contraseña. Al ejecutar las migraciones se crea, si no existe, un usuario administrador usando `ADMIN_USER` y `ADMIN_PASS` definidos en el entorno. El servidor se niega a iniciar si `ADMIN_PASS` queda en `changeme`.
+El login acepta **identificador** o email junto con la contraseña. Al ejecutar las migraciones se crea, si no existe, un usuario administrador usando `ADMIN_USER` y `ADMIN_PASS` definidos en `.env` (ver `.env.example`). El servidor se niega a iniciar si `ADMIN_PASS` queda en `changeme`.
 
 ### Endpoints principales
 
@@ -132,8 +132,7 @@ La lista completa de rutas y roles se encuentra en [docs/roles-endpoints.md](doc
 
 ```env
 SECRET_KEY=changeme
-ADMIN_USER=admin
-ADMIN_PASS=changeme
+# ADMIN_USER y ADMIN_PASS se definen en .env (ver .env.example)
 SESSION_EXPIRE_MINUTES=1440 # duración de la sesión en minutos (1 día recomendado)
 AUTH_ENABLED=true
 # se ignora en producción; allí siempre es true
@@ -141,8 +140,8 @@ COOKIE_SECURE=false
 COOKIE_DOMAIN=
 ```
 
-`SECRET_KEY` y `ADMIN_PASS` deben reemplazarse por valores robustos antes de
-iniciar la aplicación; ésta abortará el arranque si alguno permanece en
+`SECRET_KEY` y las credenciales iniciales (`ADMIN_USER` y `ADMIN_PASS`, definidas en `.env`) deben reemplazarse por valores robustos antes de
+iniciar la aplicación; ésta abortará el arranque si `ADMIN_PASS` permanece en
 `changeme`. Mantener estas claves fuera del control de versiones y rotarlas
 periódicamente.
 
@@ -359,7 +358,7 @@ variables definidas en `.env`, por lo que no es necesario configurar la URL en `
 
 ```bash
 cp .env.example .env   # en Windows usar: copy .env.example .env
-# Completar DB_URL, SECRET_KEY y ADMIN_PASS en .env
+# Completar DB_URL, SECRET_KEY y las credenciales ADMIN_USER/ADMIN_PASS en .env
 alembic -c ./alembic.ini upgrade head
 
 # Crear una nueva revisión a partir de los modelos
@@ -395,8 +394,8 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
   contraparte con el mismo puerto.
 - `LOG_LEVEL`: nivel de logging de la aplicación (`DEBUG`, `INFO`, etc.).
 - `DEBUG_SQL`: si vale `1`, SQLAlchemy mostrará cada consulta ejecutada.
-- `ADMIN_USER`, `ADMIN_PASS`: credenciales del administrador inicial. Si
-  `ADMIN_PASS` queda en `changeme`, la aplicación aborta el inicio.
+ - `ADMIN_USER`, `ADMIN_PASS`: credenciales del administrador inicial definidas en `.env` (copiado desde `.env.example`). Si
+   `ADMIN_PASS` queda en `changeme`, la aplicación aborta el inicio.
 - `MAX_UPLOAD_MB`: tamaño máximo de archivos a subir.
 - `AUTH_ENABLED`: si es `true`, requiere sesión autenticada.
 - `PRODUCTS_PAGE_MAX`: límite máximo de resultados por página.


### PR DESCRIPTION
## Resumen
- documentar en `.env.example` que ADMIN_USER/ADMIN_PASS son la referencia única del usuario inicial
- eliminar credenciales duplicadas en README y señalar `.env` como fuente de verdad

## Testing
- `pytest` *(falla: The asyncio extension requires an async driver to be used. The loaded 'pysqlite' is not async.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d486d8d883309da27d41516b0005