### PR TITLE
Reemplaza rol manager por colaborador

### DIFF
--- a/docs/roles-endpoints.md
+++ b/docs/roles-endpoints.md
@@ -23,7 +23,7 @@ Las rutas sin un rol específico son accesibles para cualquier usuario, incluido
 | GET | /categories/search | Ninguno |
 | POST | /categories/generate-from-supplier-file | admin (requiere CSRF) |
 | GET | /products | cliente, proveedor, colaborador, admin |
-| PATCH | /products/{product_id}/stock | manager, admin (requiere CSRF) |
+| PATCH | /products/{product_id}/stock | colaborador, admin (requiere CSRF) |
 | GET | /price-history | cliente, proveedor, colaborador, admin |
 | POST | /canonical-products | admin (requiere CSRF) |
 | GET | /canonical-products | Ninguno |
@@ -31,8 +31,8 @@ Las rutas sin un rol específico son accesibles para cualquier usuario, incluido
 | PATCH | /canonical-products/{canonical_id} | admin (requiere CSRF) |
 | GET | /canonical-products/{canonical_id}/offers | Ninguno |
 | GET | /equivalences | Ninguno |
-| POST | /equivalences | manager, admin (requiere CSRF) |
-| DELETE | /equivalences/{equivalence_id} | manager, admin (requiere CSRF) |
+| POST | /equivalences | colaborador, admin (requiere CSRF) |
+| DELETE | /equivalences/{equivalence_id} | colaborador, admin (requiere CSRF) |
 | GET | /suppliers/price-list/template | Ninguno |
 | GET | /suppliers/{supplier_id}/price-list/template | Ninguno |
 | POST | /suppliers/{supplier_id}/price-list/upload | proveedor, colaborador, admin (requiere CSRF) |

--- a/services/routers/canonical_products.py
+++ b/services/routers/canonical_products.py
@@ -185,7 +185,7 @@ async def list_equivalences(
 
 @equivalences_router.post(
     "",
-    dependencies=[Depends(require_csrf), Depends(require_roles("manager", "admin"))],
+    dependencies=[Depends(require_csrf), Depends(require_roles("colaborador", "admin"))],
 )
 async def upsert_equivalence(
     req: EquivalenceCreate, session: AsyncSession = Depends(get_session)
@@ -224,7 +224,7 @@ async def upsert_equivalence(
 
 @equivalences_router.delete(
     "/{equivalence_id}",
-    dependencies=[Depends(require_csrf), Depends(require_roles("manager", "admin"))],
+    dependencies=[Depends(require_csrf), Depends(require_roles("colaborador", "admin"))],
 )
 async def delete_equivalence(
     equivalence_id: int, session: AsyncSession = Depends(get_session)

--- a/services/routers/catalog.py
+++ b/services/routers/catalog.py
@@ -429,7 +429,7 @@ class StockUpdate(BaseModel):
 
 @router.patch(
     "/products/{product_id}/stock",
-    dependencies=[Depends(require_csrf), Depends(require_roles("manager", "admin"))],
+    dependencies=[Depends(require_csrf), Depends(require_roles("colaborador", "admin"))],
 )
 async def update_product_stock(
     product_id: int,


### PR DESCRIPTION
## Resumen
- Cambia el rol requerido `manager` por `colaborador` en los endpoints de catálogo y productos canónicos
- Actualiza la documentación de roles por endpoint

## Testing
- `SECRET_KEY=test ADMIN_PASS=test pytest` *(falla: 11 tests fallidos, 14 aprobados)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d70948b88330b7b37107d84c47e7