### PR TITLE
Permitir carga de listas de precios CSV

### DIFF
--- a/services/routers/imports.py
+++ b/services/routers/imports.py
@@ -229,7 +229,8 @@ async def upload_price_list(
         )
 
     filename = (file.filename or "").lower()
-    if not filename.endswith(".xlsx"):
+    # Admitimos tanto planillas Excel como archivos CSV
+    if not (filename.endswith(".xlsx") or filename.endswith(".csv")):
         raise HTTPException(status_code=400, detail="Tipo de archivo no soportado")
     content = await file.read()
 
@@ -238,7 +239,8 @@ async def upload_price_list(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception:
-        raise HTTPException(status_code=400, detail="Archivo Excel no válido")
+        # Mensaje genérico ya que puede tratarse de Excel o CSV
+        raise HTTPException(status_code=400, detail="Archivo de precios no válido")
 
     parser_kpis = {
         "total": len(parsed_rows),

--- a/services/suppliers/parsers.py
+++ b/services/suppliers/parsers.py
@@ -74,11 +74,12 @@ class BaseSupplierParser:
 
 @dataclass
 class GenericExcelParser(BaseSupplierParser):
-    """Parser configurable por YAML para planillas simples.
+    """Parser configurable por YAML para planillas Excel o CSV simples.
 
     Cada archivo ``*.yml`` describe cómo mapear las columnas externas a
     campos internos y qué transformaciones aplicar. El atributo ``slug``
-    se toma del propio YAML o del nombre del archivo.
+    se toma del propio YAML o del nombre del archivo. El tipo de archivo
+    se define mediante ``file_type`` (``xlsx`` o ``csv``).
     """
 
     slug: str
@@ -103,7 +104,7 @@ class GenericExcelParser(BaseSupplierParser):
                 header=cfg.get("header_row", 0),
             )
         else:  # pragma: no cover - validado por configuración
-            raise ValueError("Tipo de archivo no soportado")
+            raise ValueError("Tipo de archivo no soportado: use 'xlsx' o 'csv'")
 
         # normalizar encabezados
         df.columns = [str(c).strip() for c in df.columns]


### PR DESCRIPTION
## Resumen
- Aceptar archivos .csv además de .xlsx en `upload_price_list`
- Mejorar mensajes y documentación del parser genérico para reflejar soporte CSV

## Testing
- `SECRET_KEY=test ADMIN_PASS=test AUTH_ENABLED=true pytest` *(falla: 3 pruebas de suppliers por override de sesión)*
- `SECRET_KEY=test ADMIN_PASS=test AUTH_ENABLED=true pytest tests/test_suppliers_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9e8502fac8330a7004fdbdfe6ba70