### PR TITLE
refactor(frontend): reemplazar colores fijos por variables

### DIFF
--- a/frontend/src/components/CreateSupplierModal.tsx
+++ b/frontend/src/components/CreateSupplierModal.tsx
@@ -47,9 +47,9 @@ export default function CreateSupplierModal({ open, onClose, onCreated }: Props)
 
   return (
     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <div style={{ background: '#fff', padding: 20, borderRadius: 8, width: 300 }}>
+      <div style={{ background: 'var(--panel-bg)', color: 'var(--text-color)', padding: 20, borderRadius: 8, width: 300 }}>
         <h4>Nuevo proveedor</h4>
-        {error && <div style={{ color: 'red' }}>{error}</div>}
+        {error && <div style={{ color: 'var(--text-color)' }}>{error}</div>}
         <div style={{ margin: '8px 0' }}>
           <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Nombre" style={{ width: '100%', padding: 8 }} />
         </div>

--- a/frontend/src/components/ImportViewer.tsx
+++ b/frontend/src/components/ImportViewer.tsx
@@ -60,9 +60,9 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
 
   return (
     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <div style={{ background: '#fff', padding: 20, borderRadius: 8, width: '80%', maxHeight: '80%', overflow: 'auto' }}>
+      <div style={{ background: 'var(--panel-bg)', color: 'var(--text-color)', padding: 20, borderRadius: 8, width: '80%', maxHeight: '80%', overflow: 'auto' }}>
         <h3>Revisión de importación #{jobId}</h3>
-        {error && <div style={{ color: 'red' }}>{error}</div>}
+        {error && <div style={{ color: 'var(--text-color)' }}>{error}</div>}
         <div>
           <strong>KPIs:</strong>
           <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
@@ -70,7 +70,8 @@ export default function ImportViewer({ open, jobId, summary, onClose }: Props) {
               <div
                 key={k}
                 style={{
-                  background: '#f0f0f0',
+                  background: 'var(--panel-bg)',
+                  color: 'var(--text-color)',
                   padding: '4px 8px',
                   borderRadius: 4,
                   minWidth: 80,

--- a/frontend/src/components/PriceHistoryModal.tsx
+++ b/frontend/src/components/PriceHistoryModal.tsx
@@ -35,7 +35,7 @@ export default function PriceHistoryModal({ productId, supplierProductId, onClos
         justifyContent: 'center',
       }}
     >
-      <div style={{ background: '#fff', padding: 20, borderRadius: 8, width: 500 }}>
+      <div style={{ background: 'var(--panel-bg)', color: 'var(--text-color)', padding: 20, borderRadius: 8, width: 500 }}>
         <button onClick={onClose} style={{ float: 'right' }}>
           Cerrar
         </button>

--- a/frontend/src/components/SuppliersModal.tsx
+++ b/frontend/src/components/SuppliersModal.tsx
@@ -26,9 +26,9 @@ export default function SuppliersModal({ open, onClose }: Props) {
 
   return (
     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-      <div style={{ background: '#fff', padding: 20, borderRadius: 8, width: 400 }}>
+      <div style={{ background: 'var(--panel-bg)', color: 'var(--text-color)', padding: 20, borderRadius: 8, width: 400 }}>
         <h3>Proveedores</h3>
-        {error && <div style={{ color: 'red' }}>{error}</div>}
+        {error && <div style={{ color: 'var(--text-color)' }}>{error}</div>}
         {suppliers.length === 0 ? (
           <div>No hay proveedores aún</div>
         ) : (

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -12,6 +12,10 @@
   --table-header: #1b2030;
   --table-row: #121620;
   --table-row-hover: #1a1f2d;
+
+  /* Variables de alias para componentes */
+  --panel-bg: var(--panel);
+  --text-color: var(--text);
 }
 
 [data-theme="dark"] {
@@ -27,9 +31,9 @@ body {
 }
 
 .panel {
-  background: var(--panel);
+  background: var(--panel-bg);
   border: 1px solid var(--border);
-  color: var(--text);
+  color: var(--text-color);
   border-radius: 12px;
 }
 


### PR DESCRIPTION
## Resumen
- usar `var(--panel-bg)` y `var(--text-color)` en modales de proveedores, importaciones y precios
- definir alias de color en `theme.css` para soportar temas

## Pruebas
- `npm run build`
- `pytest` *(falla: SECRET_KEY debe sobrescribirse; no puede permanecer en 'changeme')*

------
https://chatgpt.com/codex/tasks/task_e_68a9e9dde2f4833090f7806ca167f7ae