### PR TITLE
feat: robustecer run_api.cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ uvicorn services.api:app --reload
 
 ## Migraciones automáticas
 
-`start.sh`, `start.bat` y `scripts/run_api.cmd` ejecutan `alembic upgrade head` con el intérprete del entorno virtual antes de iniciar el servidor.
+`start.sh`, `start.bat` y `scripts/run_api.cmd` invocan `scripts\stop.bat`, luego `scripts\fix_deps.bat` y finalmente `alembic upgrade head` con el intérprete del entorno virtual antes de iniciar el servidor.
 Si la migración falla, el proceso se detiene para evitar correr con un esquema desactualizado.
 De esta forma la base siempre está en el esquema más reciente sin comandos manuales.
 
@@ -331,6 +331,8 @@ Para detener manualmente los servicios, ejecutar `scripts\stop.bat` desde CMD; c
 Rutas con espacios soportadas (los scripts usan `cd /d` y comillas).
 
 PowerShell no requerido (los scripts son CMD puro).
+
+Para iniciar solo el backend en Windows se puede ejecutar `scripts\run_api.cmd`. Este script detiene procesos previos, instala dependencias, aplica migraciones y guarda la salida de Uvicorn en `logs/backend.log`.
 
 ### Debian/Ubuntu
 


### PR DESCRIPTION
## Summary
- detener procesos previos y verificar puerto 8000 antes de iniciar el backend
- instalar dependencias, ejecutar migraciones y redirigir logs en run_api.cmd
- documentar el nuevo flujo en README

## Testing
- `pytest` *(falla: SECRET_KEY no sobreescrito y módulo aiosqlite ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68a9eb22f2a483309724a3ee20461ada