### PR TITLE
Implementar intents de stock, import y búsqueda con lógica real

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ En el chat o vía API se pueden usar:
 - `/sync pull --dry-run`
 - `/sync push --dry-run`
 - `/stock adjust --sku=SKU --qty=5`
+- `/import archivo.xlsx --supplier=SLUG`
 - `/import last --apply`
 - `/search maceta`
 

--- a/services/intents/handlers.py
+++ b/services/intents/handlers.py
@@ -1,6 +1,15 @@
 """Handlers de intents de ejemplo."""
-from typing import Any, Dict, List
 
+from typing import Any, Dict, List
+import asyncio
+from sqlalchemy import select
+
+from db.session import SessionLocal
+from db.models import Variant, Inventory, Supplier
+from services.routers.catalog import update_product_stock, StockUpdate
+from services.routers import catalog as catalog_router
+from services.routers import imports as imports_router
+from services.suppliers.parsers import SUPPLIER_PARSERS
 
 
 def handle_help(args: List[str], opts: Dict[str, Any]) -> Dict[str, str]:
@@ -15,45 +24,152 @@ def handle_help(args: List[str], opts: Dict[str, Any]) -> Dict[str, str]:
 
 
 def handle_stock(args: List[str], opts: Dict[str, Any]) -> Dict[str, Any]:
-    """Ejecuta operaciones de stock básicas."""
+    """Ejecuta operaciones de stock contra el catálogo."""
     if not args:
         return {"message": "Acción requerida: adjust|min"}
     action = args[0]
     sku = opts.get("sku")
-    qty = opts.get("qty")
+    qty_raw = opts.get("qty")
+    qty = int(qty_raw) if qty_raw is not None else None
+    if not sku or qty is None:
+        return {"message": "sku y qty requeridos"}
+
     if action == "adjust":
-        return {
-            "message": f"Stock ajustado para {sku} en {qty}",
-            "action": "adjust",
-            "sku": sku,
-            "qty": int(qty) if isinstance(qty, str) and qty.isdigit() else qty,
-        }
+        async def _adjust() -> Dict[str, Any] | None:
+            async with SessionLocal() as session:
+                var = await session.scalar(select(Variant).where(Variant.sku == sku))
+                if not var:
+                    return None
+                inv = await session.scalar(
+                    select(Inventory).where(Inventory.variant_id == var.id)
+                )
+                if not inv:
+                    inv = Inventory(variant_id=var.id, stock_qty=qty)
+                    session.add(inv)
+                else:
+                    inv.stock_qty = qty
+                await update_product_stock(
+                    var.product_id, StockUpdate(stock=qty), session=session
+                )
+                await session.commit()
+                return {
+                    "action": "adjust",
+                    "sku": sku,
+                    "qty": qty,
+                    "product_id": var.product_id,
+                }
+
+        res = asyncio.run(_adjust())
+        if not res:
+            return {"message": f"SKU no encontrado: {sku}"}
+        res["message"] = f"Stock ajustado para {sku} en {qty}"
+        return res
+
     if action == "min":
-        return {
-            "message": f"Stock mínimo de {sku} en {qty}",
-            "action": "min",
-            "sku": sku,
-            "min": int(qty) if isinstance(qty, str) and qty.isdigit() else qty,
-        }
+        async def _min() -> Dict[str, Any] | None:
+            async with SessionLocal() as session:
+                var = await session.scalar(select(Variant).where(Variant.sku == sku))
+                if not var:
+                    return None
+                inv = await session.scalar(
+                    select(Inventory).where(Inventory.variant_id == var.id)
+                )
+                if not inv:
+                    inv = Inventory(variant_id=var.id, stock_qty=0, min_qty=qty)
+                    session.add(inv)
+                else:
+                    inv.min_qty = qty
+                await session.commit()
+                return {
+                    "action": "min",
+                    "sku": sku,
+                    "min": qty,
+                }
+
+        res = asyncio.run(_min())
+        if not res:
+            return {"message": f"SKU no encontrado: {sku}"}
+        res["message"] = f"Stock mínimo de {sku} en {qty}"
+        return res
+
     return {"message": f"Acción desconocida: {action}"}
 
 
 def handle_import(args: List[str], opts: Dict[str, Any]) -> Dict[str, Any]:
-    """Simula la importación de archivos de proveedores."""
+    """Importa archivos de proveedores usando los parsers disponibles."""
     if not args:
         return {"message": "Falta archivo a importar"}
     filename = args[0]
-    supplier = opts.get("supplier")
+    supplier_slug = opts.get("supplier")
     dry_run = bool(opts.get("dry_run") or opts.get("dry-run"))
+    if not supplier_slug:
+        return {"message": "Proveedor requerido"}
+
+    parser = SUPPLIER_PARSERS.get(supplier_slug)
+    if not parser:
+        return {"message": f"Parser no encontrado para {supplier_slug}"}
+    with open(filename, "rb") as fh:
+        rows = parser.parse_bytes(fh.read())
+
+    if dry_run:
+        ok_rows = sum(1 for r in rows if r.get("status") == "ok")
+        return {
+            "message": f"{ok_rows} filas procesadas (dry_run)",
+            "rows": ok_rows,
+            "dry_run": True,
+            "file": filename,
+            "supplier": supplier_slug,
+        }
+
+    async def _apply() -> Dict[str, Any]:
+        async with SessionLocal() as session:
+            supplier = await session.scalar(
+                select(Supplier).where(Supplier.slug == supplier_slug)
+            )
+            if not supplier:
+                return {"error": f"Proveedor {supplier_slug} no encontrado"}
+            imported = 0
+            for row in rows:
+                if row.get("status") != "ok":
+                    continue
+                cat = await imports_router._get_or_create_category_path(
+                    session, row.get("categoria_path", "")
+                )
+                prod = await imports_router._upsert_product(
+                    session, row["codigo"], row["nombre"], cat
+                )
+                await imports_router._upsert_supplier_product(
+                    session, supplier.id, row, prod
+                )
+                imported += 1
+            await session.commit()
+            return {"imported": imported}
+
+    result = asyncio.run(_apply())
+    if "error" in result:
+        return {"message": result["error"]}
     return {
-        "message": f"Importando {filename} (supplier={supplier}, dry_run={dry_run})",
+        "message": f"Importadas {result['imported']} filas",
+        "imported": result["imported"],
         "file": filename,
-        "supplier": supplier,
-        "dry_run": dry_run,
+        "supplier": supplier_slug,
+        "dry_run": False,
     }
 
 
 def handle_search(args: List[str], opts: Dict[str, Any]) -> Dict[str, Any]:
-    """Busca productos por texto o SKU."""
+    """Busca productos utilizando el catálogo."""
     query = " ".join(args) or opts.get("q", "")
-    return {"message": f"Buscando '{query}'", "query": query}
+    if not query:
+        return {"message": "Texto de búsqueda requerido", "items": []}
+
+    async def _search() -> Dict[str, Any]:
+        async with SessionLocal() as session:
+            return await catalog_router.list_products(q=query, session=session)
+
+    data = asyncio.run(_search())
+    return {
+        "message": f"{data['total']} resultados para '{query}'",
+        "items": data["items"],
+        "query": query,
+    }

--- a/tests/test_intents_handlers.py
+++ b/tests/test_intents_handlers.py
@@ -1,0 +1,128 @@
+"""Pruebas de los handlers de intents."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pandas as pd
+from sqlalchemy import select
+
+from db.session import engine, SessionLocal
+from db.models import Base, Product, Variant, Inventory, Supplier, SupplierProduct
+from services.intents import handlers
+
+
+async def _init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def test_handle_stock_adjust_and_min() -> None:
+    async def setup() -> None:
+        await _init_db()
+        async with SessionLocal() as session:
+            prod = Product(sku_root="SKU1", title="Producto")
+            session.add(prod)
+            await session.flush()
+            var = Variant(product_id=prod.id, sku="SKU1")
+            session.add(var)
+            await session.flush()
+            inv = Inventory(variant_id=var.id, stock_qty=5, min_qty=1)
+            session.add(inv)
+            await session.commit()
+
+    asyncio.run(setup())
+
+    res_adjust = handlers.handle_stock(["adjust"], {"sku": "SKU1", "qty": "10"})
+    assert res_adjust["action"] == "adjust"
+
+    async def verify_adjust() -> None:
+        async with SessionLocal() as session:
+            prod = await session.scalar(select(Product).where(Product.sku_root == "SKU1"))
+            inv = await session.scalar(
+                select(Inventory).join(Variant).where(Variant.sku == "SKU1")
+            )
+            assert prod and prod.stock == 10
+            assert inv and inv.stock_qty == 10
+
+    asyncio.run(verify_adjust())
+
+    res_min = handlers.handle_stock(["min"], {"sku": "SKU1", "qty": "2"})
+    assert res_min["action"] == "min"
+
+    async def verify_min() -> None:
+        async with SessionLocal() as session:
+            inv = await session.scalar(
+                select(Inventory).join(Variant).where(Variant.sku == "SKU1")
+            )
+            assert inv and inv.min_qty == 2
+
+    asyncio.run(verify_min())
+
+
+def _create_sample_file(path: Path) -> Path:
+    df = pd.DataFrame(
+        [
+            {
+                "ID": "ABC1",
+                "Agrupamiento": "Ag",
+                "Familia": "Fam",
+                "SubFamilia": "Sub",
+                "Producto": "Maceta",
+                "Compra Minima": 1,
+                "Stock": 10,
+                "PrecioDeCompra": 5.0,
+                "PrecioDeVenta": 7.5,
+            }
+        ]
+    )
+    file_path = path / "sample.xlsx"
+    df.to_excel(file_path, sheet_name="data", index=False, startrow=1)
+    return file_path
+
+
+def test_handle_import(tmp_path: Path) -> None:
+    async def setup() -> None:
+        await _init_db()
+        async with SessionLocal() as session:
+            supplier = Supplier(slug="santa-planta", name="Santa Planta")
+            session.add(supplier)
+            await session.commit()
+
+    asyncio.run(setup())
+    file_path = _create_sample_file(tmp_path)
+
+    res = handlers.handle_import([str(file_path)], {"supplier": "santa-planta"})
+    assert res["imported"] == 1
+
+    async def verify() -> None:
+        async with SessionLocal() as session:
+            prod = await session.scalar(select(Product).where(Product.sku_root == "ABC1"))
+            sp = await session.scalar(
+                select(SupplierProduct).where(
+                    SupplierProduct.supplier_product_id == "ABC1"
+                )
+            )
+            assert prod is not None
+            assert sp is not None
+
+    asyncio.run(verify())
+
+
+def test_handle_search(tmp_path: Path) -> None:
+    async def setup() -> None:
+        await _init_db()
+        async with SessionLocal() as session:
+            supplier = Supplier(slug="santa-planta", name="Santa Planta")
+            session.add(supplier)
+            await session.commit()
+
+    asyncio.run(setup())
+    file_path = _create_sample_file(tmp_path)
+    handlers.handle_import([str(file_path)], {"supplier": "santa-planta"})
+
+    res = handlers.handle_search(["Maceta"], {})
+    assert res["items"]
+    assert res["items"][0]["name"] == "Maceta"


### PR DESCRIPTION
## Resumen
- Conectar el intent de **stock** con el catálogo para ajustar niveles y mínimos.
- Permitir que el intent de **import** procese archivos de proveedores y actualice la base de datos.
- Agregar búsqueda de productos al intent **search** usando el catálogo.
- Documentar uso de `/import archivo.xlsx --supplier=SLUG`.

## Pruebas
- `SECRET_KEY=test ADMIN_PASS=test pytest tests/test_intents_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9ecedaad483309dc7ba1e8465cb53