### PR TITLE
Usar placeholders para SECRET_KEY y ADMIN_PASS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,8 @@ LOG_LEVEL=INFO
 DEBUG_SQL=0
 
 # Auth y seguridad
-# SECRET_KEY, ADMIN_USER y ADMIN_PASS deben sobrescribirse; la aplicación abortará si SECRET_KEY o ADMIN_PASS quedan en 'changeme'
-SECRET_KEY=changeme
+# SECRET_KEY, ADMIN_USER y ADMIN_PASS deben sobrescribirse; la aplicación abortará si SECRET_KEY o ADMIN_PASS quedan en los placeholders
+SECRET_KEY=REEMPLAZAR_SECRET_KEY
 # Duración de la sesión en minutos.
 # El valor sugerido de 1440 (1 día) equilibra seguridad y comodidad:
 # valores mayores prolongan el login pero aumentan el riesgo si se roban cookies;
@@ -51,7 +51,7 @@ COOKIE_DOMAIN=
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # Usuario administrador inicial; si no existe, se crea al ejecutar migraciones
 ADMIN_USER=admin
-ADMIN_PASS=changeme
+ADMIN_PASS=REEMPLAZAR_ADMIN_PASS
 MAX_UPLOAD_MB=8
 AUTH_ENABLED=true
 PRODUCTS_PAGE_MAX=100

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -e .[dev]
 cp .env.example .env
-# reemplazar SECRET_KEY, ADMIN_USER y ADMIN_PASS antes de continuar
+# reemplazar los placeholders SECRET_KEY, ADMIN_USER y ADMIN_PASS antes de continuar
 # las variables de entorno se cargan automáticamente desde .env
 # crear base de datos growen en PostgreSQL
 alembic -c ./alembic.ini upgrade head
@@ -103,7 +103,7 @@ En desarrollo, Vite proxya `/ws`, `/chat` y `/actions` hacia `http://localhost:8
 
 La API implementa sesiones mediante la cookie `growen_session` y un token CSRF almacenado en `csrf_token`. Cada vez que se inicia o cierra sesión se generan nuevos valores para ambas cookies, evitando la fijación de sesiones. Todas las mutaciones deben enviar el encabezado `X-CSRF-Token` coincidiendo con dicha cookie. Las rutas que modifican datos añaden dependencias `require_roles` para comprobar que el usuario posea el rol autorizado.
 
-El login acepta **identificador** o email junto con la contraseña. Al ejecutar las migraciones se crea, si no existe, un usuario administrador usando `ADMIN_USER` y `ADMIN_PASS` definidos en `.env` (ver `.env.example`). El servidor se niega a iniciar si `ADMIN_PASS` queda en `changeme`.
+ El login acepta **identificador** o email junto con la contraseña. Al ejecutar las migraciones se crea, si no existe, un usuario administrador usando `ADMIN_USER` y `ADMIN_PASS` definidos en `.env` (ver `.env.example`). El servidor se niega a iniciar si `ADMIN_PASS` queda en el placeholder `REEMPLAZAR_ADMIN_PASS`.
 
 ### Endpoints principales
 
@@ -131,8 +131,8 @@ La lista completa de rutas y roles se encuentra en [docs/roles-endpoints.md](doc
 ### Variables de entorno relevantes
 
 ```env
-SECRET_KEY=changeme
-# ADMIN_USER y ADMIN_PASS se definen en .env (ver .env.example)
+SECRET_KEY=REEMPLAZAR_SECRET_KEY
+# ADMIN_USER y ADMIN_PASS se definen en .env (ver .env.example); cambie los placeholders
 SESSION_EXPIRE_MINUTES=1440 # duración de la sesión en minutos (1 día recomendado)
 AUTH_ENABLED=true
 # se ignora en producción; allí siempre es true
@@ -141,8 +141,7 @@ COOKIE_DOMAIN=
 ```
 
 `SECRET_KEY` y las credenciales iniciales (`ADMIN_USER` y `ADMIN_PASS`, definidas en `.env`) deben reemplazarse por valores robustos antes de
-iniciar la aplicación; ésta abortará el arranque si `ADMIN_PASS` permanece en
-`changeme`. Mantener estas claves fuera del control de versiones y rotarlas
+iniciar la aplicación; ésta abortará el arranque si `ADMIN_PASS` permanece en el placeholder `REEMPLAZAR_ADMIN_PASS`. Mantener estas claves fuera del control de versiones y rotarlas
 periódicamente.
 
 `SESSION_EXPIRE_MINUTES` define cuánto tiempo permanece válida una sesión.
@@ -361,7 +360,7 @@ variables definidas en `.env`, por lo que no es necesario configurar la URL en `
 
 ```bash
 cp .env.example .env   # en Windows usar: copy .env.example .env
-# Completar DB_URL, SECRET_KEY y las credenciales ADMIN_USER/ADMIN_PASS en .env
+# Completar DB_URL, SECRET_KEY y las credenciales ADMIN_USER/ADMIN_PASS (reemplazar placeholders) en .env
 alembic -c ./alembic.ini upgrade head
 
 # Crear una nueva revisión a partir de los modelos
@@ -384,8 +383,8 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
 - `OLLAMA_URL`: URL base de Ollama (por defecto `http://localhost:11434`).
 - `OLLAMA_MODEL`: modelo de Ollama (por defecto `llama3.1`).
 - `OPENAI_API_KEY`, `OPENAI_MODEL`.
-- `SECRET_KEY`: clave usada para firmar sesiones; debe cambiarse del valor
-  por defecto `changeme`, rotarse periódicamente y mantenerse fuera del
+- `SECRET_KEY`: clave usada para firmar sesiones; reemplace el placeholder
+  `REEMPLAZAR_SECRET_KEY`, rote el valor periódicamente y manténgalo fuera del
   control de versiones. El servidor se detiene si no se sobrescribe.
 - `SESSION_EXPIRE_MINUTES`: tiempo de expiración de la sesión en minutos (por
   defecto 1440 = 1 día). Incrementarlo prolonga las sesiones pero aumenta el
@@ -398,7 +397,7 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
 - `LOG_LEVEL`: nivel de logging de la aplicación (`DEBUG`, `INFO`, etc.).
 - `DEBUG_SQL`: si vale `1`, SQLAlchemy mostrará cada consulta ejecutada.
  - `ADMIN_USER`, `ADMIN_PASS`: credenciales del administrador inicial definidas en `.env` (copiado desde `.env.example`). Si
-   `ADMIN_PASS` queda en `changeme`, la aplicación aborta el inicio.
+   `ADMIN_PASS` queda en el placeholder `REEMPLAZAR_ADMIN_PASS`, la aplicación aborta el inicio.
 - `MAX_UPLOAD_MB`: tamaño máximo de archivos a subir.
 - `AUTH_ENABLED`: si es `true`, requiere sesión autenticada.
 - `PRODUCTS_PAGE_MAX`: límite máximo de resultados por página.

--- a/agent_core/config.py
+++ b/agent_core/config.py
@@ -6,6 +6,10 @@ import os
 from dataclasses import dataclass
 from dotenv import load_dotenv
 
+# Marcadores que deben sustituirse en producción
+SECRET_KEY_PLACEHOLDER = "REEMPLAZAR_SECRET_KEY"
+ADMIN_PASS_PLACEHOLDER = "REEMPLAZAR_ADMIN_PASS"
+
 # Carga automática de variables definidas en .env
 load_dotenv()
 
@@ -20,9 +24,9 @@ class Settings:
     )
     ai_mode: str = os.getenv("AI_MODE", "auto")
     ai_allow_external: bool = os.getenv("AI_ALLOW_EXTERNAL", "true").lower() == "true"
-    secret_key: str = os.getenv("SECRET_KEY", "changeme")
+    secret_key: str = os.getenv("SECRET_KEY", SECRET_KEY_PLACEHOLDER)
     admin_user: str = os.getenv("ADMIN_USER", "admin")
-    admin_pass: str = os.getenv("ADMIN_PASS", "changeme")
+    admin_pass: str = os.getenv("ADMIN_PASS", ADMIN_PASS_PLACEHOLDER)
     session_expire_minutes: int = int(
         os.getenv("SESSION_EXPIRE_MINUTES", "1440")
     )  # duración de la sesión en minutos (1 día por defecto)
@@ -31,13 +35,13 @@ class Settings:
     cookie_domain: str | None = os.getenv("COOKIE_DOMAIN") or None
 
     def __post_init__(self) -> None:
-        if self.secret_key == "changeme":
+        if self.secret_key == SECRET_KEY_PLACEHOLDER:
             raise RuntimeError(
-                "SECRET_KEY debe sobrescribirse; no puede permanecer en 'changeme'"
+                "SECRET_KEY debe sobrescribirse; reemplace el placeholder 'REEMPLAZAR_SECRET_KEY'"
             )
-        if self.admin_pass == "changeme":
+        if self.admin_pass == ADMIN_PASS_PLACEHOLDER:
             raise RuntimeError(
-                "ADMIN_PASS debe sobrescribirse; no puede permanecer en 'changeme'"
+                "ADMIN_PASS debe sobrescribirse; reemplace el placeholder 'REEMPLAZAR_ADMIN_PASS'"
             )
 
 

--- a/db/migrations/versions/20241105_auth_roles_sessions.py
+++ b/db/migrations/versions/20241105_auth_roles_sessions.py
@@ -225,10 +225,10 @@ def upgrade():
     has_admin = bind.execute(text("SELECT 1 FROM users WHERE role='admin' LIMIT 1")).first()
     if not has_admin:
         admin_user = os.getenv("ADMIN_USER", "admin")
-        admin_pass = os.getenv("ADMIN_PASS", "changeme")
-        if admin_pass == "changeme":
+        admin_pass = os.getenv("ADMIN_PASS", "REEMPLAZAR_ADMIN_PASS")
+        if admin_pass == "REEMPLAZAR_ADMIN_PASS":
             raise RuntimeError(
-                "ADMIN_PASS no puede permanecer en 'changeme' al ejecutar migraciones"
+                "ADMIN_PASS no puede permanecer en el placeholder 'REEMPLAZAR_ADMIN_PASS' al ejecutar migraciones"
             )
         pwd = argon2.using(type="ID").hash(admin_pass)
         bind.execute(


### PR DESCRIPTION
## Resumen
- Usa marcadores REEMPLAZAR_SECRET_KEY y REEMPLAZAR_ADMIN_PASS en la configuración
- Documenta en README y .env.example que los marcadores deben reemplazarse
- Ajusta migración inicial para exigir un ADMIN_PASS personalizado

## Testing
- `pytest` *(8 fallos: async def functions are not natively supported, 403 en suppliers y falta de event loop)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f924c1c883308da4fd1fef9386c2