### PR TITLE
feat: restringir orígenes en producción

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,13 @@ AI_TIMEOUT_OLLAMA_MS=12000
 AI_TIMEOUT_OPENAI_MS=60000
 
 # API Server
+# Host donde escucha la API
 HOST=0.0.0.0
+# Puerto de escucha de la API
 PORT=8000
+# Nivel de logging de la aplicación (DEBUG, INFO, etc.)
 LOG_LEVEL=INFO
+# Si vale 1, SQLAlchemy mostrará cada consulta ejecutada
 DEBUG_SQL=0
 
 # Auth y seguridad
@@ -48,15 +52,26 @@ SESSION_EXPIRE_MINUTES=1440
 # Se ignora en producción; allí siempre es true
 COOKIE_SECURE=false
 COOKIE_DOMAIN=
+# Orígenes permitidos para CORS, separados por coma. En producción
+# deben especificarse dominios exactos; en desarrollo se completan
+# automáticamente las variantes localhost/127.0.0.1
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 # Usuario administrador inicial; si no existe, se crea al ejecutar migraciones
 ADMIN_USER=admin
 ADMIN_PASS=REEMPLAZAR_ADMIN_PASS
+# Tamaño máximo de archivos que acepta la API (MB)
 MAX_UPLOAD_MB=8
+# Si es true, requiere autenticación basada en sesiones
 AUTH_ENABLED=true
+# Resultados máximos por página al listar productos
 PRODUCTS_PAGE_MAX=100
+# Cantidad de entradas por página al consultar historial de precios
 PRICE_HISTORY_PAGE_SIZE=20
+# Crea productos canónicos automáticamente al importar
 AUTO_CREATE_CANONICAL=true
+# Umbral de similitud para sugerencias difusas
 FUZZY_SUGGESTION_THRESHOLD=0.87
+# Número de sugerencias devueltas en búsquedas aproximadas
 SUGGESTION_CANDIDATES=3
-VITE_MAX_UPLOAD_MB=15 # Tamaño máximo de subida en MB para el frontend
+# Tamaño máximo de subida en MB para el frontend
+VITE_MAX_UPLOAD_MB=15

--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ Consulta `.env.example` para la lista completa. Variables destacadas:
   riesgo ante robo de cookies; reducirlo fuerza reautenticaciones más frecuentes
   y eleva la seguridad.
 - `COOKIE_SECURE`: activa cookies seguras; se ignora en producción donde siempre están habilitadas.
-- `ALLOWED_ORIGINS`: orígenes permitidos para CORS, separados por coma. Si se
-  incluye `http://localhost` o `http://127.0.0.1` se habilita automáticamente su
-  contraparte con el mismo puerto.
+- `ALLOWED_ORIGINS`: orígenes permitidos para CORS, separados por coma. En
+  desarrollo se completan automáticamente los pares `localhost`/`127.0.0.1`; en
+  producción se debe especificar cada dominio explícitamente.
 - `LOG_LEVEL`: nivel de logging de la aplicación (`DEBUG`, `INFO`, etc.).
 - `DEBUG_SQL`: si vale `1`, SQLAlchemy mostrará cada consulta ejecutada.
  - `ADMIN_USER`, `ADMIN_PASS`: credenciales del administrador inicial definidas en `.env` (copiado desde `.env.example`). Si

--- a/agent_core/config.py
+++ b/agent_core/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 # Marcadores que deben sustituirse en producción
@@ -12,6 +12,21 @@ ADMIN_PASS_PLACEHOLDER = "REEMPLAZAR_ADMIN_PASS"
 
 # Carga automática de variables definidas en .env
 load_dotenv()
+
+
+def _expand_local(origins: list[str]) -> list[str]:
+    """Duplica ``localhost``/``127.0.0.1`` para evitar errores de CORS en desarrollo."""
+    out: set[str] = set()
+    for o in origins:
+        o = o.strip()
+        if not o:
+            continue
+        out.add(o)
+        if o.startswith("http://localhost:"):
+            out.add(o.replace("http://localhost:", "http://127.0.0.1:"))
+        if o.startswith("http://127.0.0.1:"):
+            out.add(o.replace("http://127.0.0.1:", "http://localhost:"))
+    return list(out)
 
 
 @dataclass
@@ -33,6 +48,7 @@ class Settings:
     auth_enabled: bool = os.getenv("AUTH_ENABLED", "false").lower() == "true"
     cookie_secure: bool = os.getenv("COOKIE_SECURE", "false").lower() == "true"
     cookie_domain: str | None = os.getenv("COOKIE_DOMAIN") or None
+    allowed_origins: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.secret_key == SECRET_KEY_PLACEHOLDER:
@@ -43,6 +59,18 @@ class Settings:
             raise RuntimeError(
                 "ADMIN_PASS debe sobrescribirse; reemplace el placeholder 'REEMPLAZAR_ADMIN_PASS'"
             )
+
+        raw = os.getenv("ALLOWED_ORIGINS", "").split(",")
+        origins = [o.strip() for o in raw if o.strip()]
+        if self.env == "dev":
+            if not origins:
+                origins = ["http://localhost:5173"]
+            origins = _expand_local(origins)
+        elif not origins:
+            raise RuntimeError(
+                "En producción, ALLOWED_ORIGINS debe definir al menos un origen"
+            )
+        self.allowed_origins = origins
 
 
 settings = Settings()

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
+# URL base de la API usada por el frontend en desarrollo
 VITE_API_URL=http://127.0.0.1:8000

--- a/services/api.py
+++ b/services/api.py
@@ -47,27 +47,9 @@ async def log_requests(request: Request, call_next):
     logger.info("%s %s -> %s (%.2fms)", request.method, request.url.path, resp.status_code, dur)
     return resp
 
-
-def _expand_local(origins: list[str]) -> list[str]:
-    """Duplica ``localhost``/``127.0.0.1`` para evitar errores de CORS."""
-    out: set[str] = set()
-    for o in origins:
-        o = o.strip()
-        if not o:
-            continue
-        out.add(o)
-        if o.startswith("http://localhost:"):
-            out.add(o.replace("http://localhost:", "http://127.0.0.1:"))
-        if o.startswith("http://127.0.0.1:"):
-            out.add(o.replace("http://127.0.0.1:", "http://localhost:"))
-    return list(out)
-
-
-allowed = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
-allowed = _expand_local(allowed)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=allowed,
+    allow_origins=settings.allowed_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],


### PR DESCRIPTION
## Resumen
- forzar listado de orígenes CORS vía `Settings` y exigirlo en producción
- documentar variables de entorno y parámetros de CORS
- aclarar uso de la API en `.env.example` del frontend

## Testing
- `pytest` *(falla: SECRET_KEY debe sobrescribirse y falta aiosqlite)*
- `ruff check .` *(falla: múltiples imports sin usar y variables sin usar)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fa8815688330b9003928e8772fc8