### PR TITLE
Corregir orden de flags Alembic y robustecer migraciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ Orden de ejecución recomendado:
 3. `scripts\run_migrations.cmd`
 4. Inicio de backend y frontend
 
+## Troubleshooting
+
+### Migraciones
+
+- Cada ejecución de `scripts\run_migrations.cmd` genera un archivo en `logs\migrations\alembic_YYYYMMDD_HHMMSS.log` con todo el `stdout` y `stderr` de Alembic.
+- Si el arranque se detiene por un error de migración, revisar la ruta indicada y solucionar el problema antes de volver a ejecutar `start.bat`.
+- Al invocar Alembic manualmente, las opciones globales como `--raiseerr` y `-x log_sql=1` deben ubicarse **antes** del subcomando. Ejemplo:
+
+```
+alembic --raiseerr -x log_sql=1 -c alembic.ini upgrade head
+```
+
 ## Instalación Frontend
 
 ```bash

--- a/fix_deps.bat
+++ b/fix_deps.bat
@@ -1,0 +1,4 @@
+@echo off
+rem Wrapper para compatibilidad: delega a scripts\fix_deps.bat
+call "%~dp0scripts\fix_deps.bat" %*
+exit /b %ERRORLEVEL%

--- a/scripts/run_migrations.cmd
+++ b/scripts/run_migrations.cmd
@@ -1,18 +1,39 @@
 @echo off
-setlocal ENABLEDELAYEDEXPANSION
+setlocal enabledelayedexpansion
 
+REM Raíz del repo (carpeta del script)
 set "ROOT=%~dp0.."
+REM Normalizar barra final
+for %%I in ("%ROOT%") do set "ROOT=%%~fI"
+
+REM Carpeta de logs
 set "LOGDIR=%ROOT%\logs\migrations"
 if not exist "%LOGDIR%" mkdir "%LOGDIR%"
-for /f "tokens=1-2 delims=/ " %%a in ("%date% %time%") do set TS=%%a_%%b
-set TS=%TS::=%
-set "MIGLOG=%LOGDIR%\alembic_!TS!.log"
 
-"%ROOT%\.venv\Scripts\python.exe" -m alembic -c "%ROOT%\alembic.ini" upgrade head --raiseerr -x log_sql=1 > "%MIGLOG%" 2>&1
-if errorlevel 1 (
-  echo Error al aplicar migraciones. Ver %MIGLOG%
+REM Timestamp seguro usando WMIC (formato yyyymmdd_HHMMSS)
+for /f %%i in ('wmic os get localdatetime ^| find "."') do set "TS=%%i"
+set "TS=%TS:~0,8%_%TS:~8,6%"
+REM TODO: si WMIC no está disponible, usar date /t y time /t como fallback.
+
+set "MIGLOG=%LOGDIR%\alembic_%TS%.log"
+
+REM Resolver Python del venv
+set "PYTHON=%ROOT%\.venv\Scripts\python.exe"
+if not exist "%PYTHON%" (
+  echo [ERROR] No se encontró Python del entorno virtual en "%PYTHON%"
   exit /b 1
 )
 
-echo Migraciones aplicadas con exito. Log: %MIGLOG%
+REM Ejecutar migraciones con opciones GLOBALES antes del subcomando
+echo [INFO] Ejecutando: alembic --raiseerr -x log_sql=1 -c "%ROOT%\alembic.ini" upgrade head
+"%PYTHON%" -m alembic --raiseerr -x log_sql=1 -c "%ROOT%\alembic.ini" upgrade head 1>>"%MIGLOG%" 2>&1
+
+if errorlevel 1 (
+  echo [ERROR] Fallo al aplicar migraciones. Revise el log:
+  echo        "%MIGLOG%"
+  exit /b 1
+)
+
+echo [INFO] Migraciones aplicadas con éxito. Log:
+echo        "%MIGLOG%"
 exit /b 0

--- a/start.bat
+++ b/start.bat
@@ -3,7 +3,6 @@ setlocal ENABLEDELAYEDEXPANSION
 
 rem Rutas base del repositorio
 set "ROOT=%~dp0"
-set "SCRIPTS=%ROOT%scripts"
 set "VENV=%ROOT%.venv\Scripts"
 if not defined LOG_DIR set "LOG_DIR=%ROOT%logs"
 if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
@@ -24,7 +23,7 @@ if %ERRORLEVEL% NEQ 0 (
 )
 
 call :log "[INFO] Cerrando procesos previos..."
-if exist "%SCRIPTS%\stop.bat" call "%SCRIPTS%\stop.bat"
+if exist "%~dp0stop.bat" call "%~dp0stop.bat"
 timeout /t 2 /nobreak >NUL
 
 call :log "[INFO] Verificando puertos 8000 y 5173..."
@@ -38,19 +37,17 @@ for %%P in (8000 5173) do (
 )
 
 call :log "[INFO] Instalando dependencias..."
-call "%SCRIPTS%\fix_deps.bat"
-if !ERRORLEVEL! NEQ 0 (
+call "%~dp0fix_deps.bat"
+if errorlevel 1 (
   call :log "[ERROR] Fallo la instalacion de dependencias"
-  pause
   exit /b 1
 )
 
 call :log "[INFO] Ejecutando migraciones..."
-call "%SCRIPTS%\run_migrations.cmd" >> "%LOG_FILE%" 2>&1
-if !ERRORLEVEL! NEQ 0 (
-  call :log "[ERROR] Fallo al aplicar migraciones. Revisar logs/migrations"
-  pause
-  exit /b 1
+call "%~dp0scripts\run_migrations.cmd"
+if errorlevel 1 (
+  call :log "[ERROR] No se iniciará el servidor debido a errores de migración."
+  goto :eof
 )
 
 call :log "[INFO] Iniciando backend..."

--- a/stop.bat
+++ b/stop.bat
@@ -1,0 +1,4 @@
+@echo off
+rem Wrapper para compatibilidad: delega a scripts\stop.bat
+call "%~dp0scripts\stop.bat" %*
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Resumen
- Mejorar script de migraciones en CMD con timestamp seguro y flags globales antes de `upgrade`.
- Ajustar `start.bat` para detener servicios previos, instalar dependencias y abortar si fallan migraciones.
- Añadir wrappers `fix_deps.bat` y `stop.bat` en la raíz para facilitar invocación.
- Documentar en README cómo revisar logs de migraciones y orden correcto de flags.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa53b7aedc8330bf27b682b6e73226