### PR TITLE
fix: compatibilidad log_sql en Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Orden de ejecución recomendado:
 - `alembic.ini` define `script_location = %(here)s/db/migrations`, por lo que las rutas se resuelven respecto al archivo y no al directorio actual.
 - Cada ejecución de `scripts\run_migrations.cmd` genera un archivo en `logs\migrations\alembic_YYYYMMDD_HHMMSS.log` con todo el `stdout` y `stderr` de Alembic.
 - Si el arranque se detiene por un error de migración, revisar la ruta indicada y solucionar el problema antes de volver a ejecutar `start.bat`.
-- Al invocar Alembic manualmente, las opciones globales como `--raiseerr` y `-x log_sql=1` deben ubicarse **antes** del subcomando. Ejemplo:
+- Al invocar Alembic manualmente, las opciones globales como `--raiseerr` y `-x log_sql=1` deben ubicarse **antes** del subcomando. `log_sql=1` activa `sqlalchemy.echo` para registrar cada consulta. Ejemplo:
 
 ```
 alembic --raiseerr -x log_sql=1 -c alembic.ini upgrade head


### PR DESCRIPTION
## Resumen
- compatibilizar la lectura de `-x` entre versiones de Alembic
- activar `sqlalchemy.echo` al pasar `-x log_sql=1`
- documentar uso de `log_sql`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab693d06608330b56ac1080aab74ef