### PR TITLE
fix: manejar % en DB_URL de Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ alembic -c ./alembic.ini downgrade -1
 
 Consulta `.env.example` para la lista completa. Variables destacadas:
 
-- `DB_URL`: URL de PostgreSQL (obligatoria; la aplicación no arranca si falta. Si la contraseña tiene caracteres reservados, encodéalos, ej.: `=` → `%3D`).
+- `DB_URL`: URL de PostgreSQL (obligatoria; la aplicación no arranca si falta. Si la contraseña tiene caracteres reservados, encodéalos, ej.: `=` → `%3D`. Si tu contraseña tiene caracteres raros, ponela sin encodar en variables separadas y construí la URL con `SQLAlchemy URL.create()`; pero si usás `DB_URL` ya encodada, el `env.py` ahora la maneja bien.).
 - `AI_MODE`: `auto`, `openai` u `ollama`.
 - `AI_ALLOW_EXTERNAL`: si es `false`, solo se usa Ollama.
 - `OLLAMA_URL`: URL base de Ollama (por defecto `http://localhost:11434`).

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -92,16 +92,20 @@ def run_migrations_online() -> None:
                 x_args[arg] = None
 
     log_sql = _coerce_bool(x_args.get("log_sql"))
-    config.set_main_option("sqlalchemy.url", db_url)
+    section = config.get_section(config.config_ini_section) or {}
+    section["sqlalchemy.url"] = db_url
     if log_sql:
-        config.set_main_option("sqlalchemy.echo", "true")
+        section["sqlalchemy.echo"] = "true"
+    logger.info(
+        "sqlalchemy.url inyectada via sección de config (sin set_main_option)"
+    )
+    logger.info("sqlalchemy.echo activado: %s", log_sql)
     connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
+        section,
         prefix="sqlalchemy.",
         poolclass=NullPool,
         future=True,
     )
-    logger.info("sqlalchemy.echo activado: %s", log_sql)
     with connectable.connect() as connection:
         current_rev = MigrationContext.configure(connection).get_current_revision()
         heads = script.get_heads()


### PR DESCRIPTION
## Summary
- evitar ValueError de configparser al inyectar la URL de la base con `%`
- documentar manejo de contraseñas con caracteres especiales

## Testing
- `pytest`
- `DB_URL='sqlite:///test%3Ddb.sqlite' alembic --raiseerr -x log_sql=1 -c alembic.ini current`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d16dff48330bbe7ad80d9f80148