### PR TITLE
chore(scripts): robust Windows start/stop with quoted paths, migrations logging and dual window launch

### DIFF
--- a/scripts/migrate.bat
+++ b/scripts/migrate.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal EnableExtensions
+chcp 65001 >nul
+
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+pushd "%ROOT%"
+
+if exist .venv\Scripts\activate.bat call .venv\Scripts\activate.bat
+
+if not exist "%ROOT%\logs\migrations" mkdir "%ROOT%\logs\migrations"
+
+REM Nombre de log sin espacios en hora/fecha
+set "_ts=%date:~-4%%date:~3,2%%date:~0,2%_%time:~0,2%%time:~3,2%%time:~6,2%"
+set "_ts=%_ts: =0%"
+set "LOG=logs\migrations\alembic_%_ts%.log"
+
+echo [INFO] Ejecutando migraciones... > "%LOG%"
+
+REM Si se pasa /sql o -sql, activar echo SQL (equivalente a -x log_sql=1 en Alembic moderno)
+set "EXTRA="
+if /I "%~1"==/sql set "EXTRA=-x log_sql=1"
+if /I "%~1"==-sql set "EXTRA=-x log_sql=1"
+
+alembic upgrade head %EXTRA% >> "%LOG%" 2>&1
+if errorlevel 1 (
+  echo [ERROR] Fallo al aplicar migraciones. Ver "%LOG%"
+  popd
+  exit /b 1
+) else (
+  echo [OK] Migraciones aplicadas. >> "%LOG%"
+)
+
+popd
+exit /b

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -1,0 +1,41 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+chcp 65001 >nul
+
+REM Detectar raíz del repo (scripts\ está dentro del repo)
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+echo [INFO] ROOT: "%ROOT%"
+
+REM 1) Parar procesos previos
+if exist "%ROOT%\scripts\stop.bat" (
+  call "%ROOT%\scripts\stop.bat"
+  timeout /t 2 /nobreak >nul
+)
+
+REM 2) Ejecutar migraciones (con log). Para ver SQL usar: start.bat /sql
+set "MIGR_ARG="
+if /I "%~1"==/sql set "MIGR_ARG=/sql"
+if /I "%~1"==-sql set "MIGR_ARG=/sql"
+
+if exist "%ROOT%\scripts\migrate.bat" (
+  call "%ROOT%\scripts\migrate.bat" %MIGR_ARG%
+  if errorlevel 1 (
+    echo [ERROR] Migraciones fallaron. Abortando arranque.
+    exit /b 1
+  )
+)
+
+REM 3) Lanzar API (Uvicorn) en otra ventana
+start "Growen API" cmd /k ^
+  "pushd \"%ROOT%\" && ^
+   if exist .venv\Scripts\activate.bat (call .venv\Scripts\activate.bat) else (echo [WARN] .venv no encontrado) && ^
+   set UVICORN_RELOAD_DELAY=0.25 && ^
+   python -m uvicorn services.api:app --reload --host 127.0.0.1 --port 8000"
+
+REM 4) Lanzar Frontend (Vite) en otra ventana
+start "Growen Frontend" cmd /k ^
+  "pushd \"%ROOT%\frontend\" && ^
+   if exist package.json (call npm i --no-fund --loglevel=error) else (echo [ERROR] package.json no encontrado & exit /b 1) && ^
+   npm run dev"
+
+exit /b

--- a/scripts/stop.bat
+++ b/scripts/stop.bat
@@ -1,29 +1,12 @@
 @echo off
-setlocal ENABLEDELAYEDEXPANSION
+setlocal EnableExtensions
 
-rem Directorios
-set "ROOT=%~dp0.."
-if not defined LOG_DIR set "LOG_DIR=%ROOT%\logs"
-if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
-set "LOG_FILE=%LOG_DIR%\stop.log"
+REM Matar procesos que usen los puertos 8000 (API) y 5173 (Vite)
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr :8000') do taskkill /PID %%P /F >nul 2>&1
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr :5173') do taskkill /PID %%P /F >nul 2>&1
 
-rem Validar dependencias
-where python >NUL 2>&1
-if %ERRORLEVEL% NEQ 0 call :log "[WARN] python no esta instalado"
-where npm >NUL 2>&1
-if %ERRORLEVEL% NEQ 0 call :log "[WARN] npm no esta instalado"
+REM Matar procesos huérfanos típicos
+taskkill /IM node.exe /F >nul 2>&1
+taskkill /IM python.exe /F >nul 2>&1
 
-call :log "[INFO] Cerrando procesos uvicorn y vite..."
-for /f "tokens=2 delims=," %%p in ('tasklist /FI "IMAGENAME eq python.exe" /FO CSV ^| findstr /I "uvicorn"') do taskkill /PID %%~p /F >NUL 2>&1
-for /f "tokens=2 delims=," %%p in ('tasklist /FI "IMAGENAME eq node.exe"   /FO CSV ^| findstr /I "vite"') do taskkill /PID %%~p /F >NUL 2>&1
-call :log "[INFO] Procesos finalizados"
-
-endlocal
-exit /b 0
-
-:log
-set "ts=!DATE! !TIME!"
->>"%LOG_FILE%" echo [!ts!] %~1
-echo [!ts!] %~1
-exit /b 0
-
+exit /b


### PR DESCRIPTION
## Summary
- ensure stop.bat liberates puertos 8000 y 5173 y elimina procesos huérfanos
- add migrate.bat con log y bandera opcional para mostrar SQL
- implement start.bat que orquesta stop -> migrate -> API y frontend en ventanas separadas y documenta rutas con espacios

## Testing
- `pytest`
- `cd frontend && npm test` *(falla: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab75742f4883308f0275b77e8c8150