### PR TITLE
fix: corregir inicio de backend en script de Windows

### DIFF
--- a/scripts/run_api.cmd
+++ b/scripts/run_api.cmd
@@ -42,7 +42,7 @@ if !ERRORLEVEL! NEQ 0 (
 popd
 
 call :log "[INFO] Iniciando backend..."
-start "Growen API" cmd /k "\"%VENV%\\python.exe\" -m uvicorn services.api:app --host 127.0.0.1 --port 8000 --reload --log-level info --access-log >> \"%LOG_DIR%\\backend.log\" 2>&1"
+start "Growen API" cmd /k ""%VENV%\python.exe" -m uvicorn services.api:app --host 127.0.0.1 --port 8000 --reload --log-level info --access-log >> "%LOG_DIR%\backend.log" 2>&1"
 
 endlocal
 exit /b 0


### PR DESCRIPTION
## Resumen
- corregir llamada a `start` en `run_api.cmd` para abrir la API en ventana identificada y con logs

## Pruebas
- `pytest`
- `wine cmd /c "scripts\\run_api.cmd"` *(falla: it looks like wine32 is missing, you should install it.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab782a31648330b6d37af8b73cae26