### PR TITLE
fix: corregir comillas en scripts de arranque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 - dev: valores por defecto inseguros para SECRET_KEY y ADMIN_PASS en `ENV=dev` (evita fallos en pruebas)
 - deps: incluir `aiosqlite` para motor SQLite asíncrono
 - dev: en ausencia de sesión y con `ENV=dev` se asume rol `admin` para facilitar pruebas
+- fix: corregir comillas en `scripts/start.bat` y `start.bat` para rutas con espacios

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -27,14 +27,14 @@ if exist "%ROOT%\scripts\migrate.bat" (
 
 REM 3) Lanzar API (Uvicorn) en otra ventana
 start "Growen API" cmd /k ^
-  "pushd \"%ROOT%\" && ^
+  "pushd ""%ROOT%"" && ^
    if exist .venv\Scripts\activate.bat (call .venv\Scripts\activate.bat) else (echo [WARN] .venv no encontrado) && ^
    set UVICORN_RELOAD_DELAY=0.25 && ^
    python -m uvicorn services.api:app --reload --host 127.0.0.1 --port 8000"
 
 REM 4) Lanzar Frontend (Vite) en otra ventana
 start "Growen Frontend" cmd /k ^
-  "pushd \"%ROOT%\frontend\" && ^
+  "pushd ""%ROOT%\frontend"" && ^
    if exist package.json (call npm i --no-fund --loglevel=error) else (echo [ERROR] package.json no encontrado & exit /b 1) && ^
    npm run dev"
 

--- a/start.bat
+++ b/start.bat
@@ -51,12 +51,10 @@ if errorlevel 1 (
 )
 
 call :log "[INFO] Iniciando backend..."
-start "Growen API" cmd /k "\"%VENV%\\python.exe\" -m uvicorn services.api:app --host 127.0.0.1 --port 8000 >> \"%LOG_DIR%\\backend.log\" 2>&1"
+start "Growen API" cmd /k ""%VENV%\python.exe" -m uvicorn services.api:app --host 127.0.0.1 --port 8000 >> "%LOG_DIR%\backend.log" 2>&1"
 
 call :log "[INFO] Iniciando frontend..."
-pushd "%ROOT%frontend"
-start "Growen Frontend" cmd /k "npm run dev >> \"%LOG_DIR%\\frontend.log\" 2>&1"
-popd
+start "Growen Frontend" cmd /k "pushd ""%ROOT%frontend"" && npm run dev >> ""%LOG_DIR%\frontend.log"" 2>&1"
 
 endlocal
 exit /b 0


### PR DESCRIPTION
## Resumen
- Asegurar comillas dobles en `scripts/start.bat` para `pushd` a rutas con espacios
- Usar patrón `cmd /k ""programa"" args` en `start.bat` y mover `pushd` del frontend dentro del `start`
- Documentar corrección en `CHANGELOG.md`

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8007be288330a66a299fc5433d93