### PR TITLE
Corregir comillas en start.bat y documentar patrón de ejecución

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ SELECT column_name FROM information_schema.columns
 - **UndefinedTable / UndefinedColumn**: revisar `logs/migrations/alembic_<timestamp>.log`; puede indicar que falta una migración previa.
 - **DuplicateTable / DuplicateIndex**: las migraciones actuales son idempotentes; reejecutarlas no debería fallar.
 - **Seeds inválidos**: asegurarse de que las columnas requeridas existan antes de insertar datos.
-- **Acceso denegado al iniciar en Windows**: versiones anteriores de `start.bat` no escapaban correctamente rutas con espacios, lo que impedía abrir el frontend. Actualizá el repositorio y ejecutá el script desde la raíz del proyecto.
+- **Acceso denegado al iniciar en Windows**: `start.bat` abre procesos con `start` y `cmd /k`. Para que Windows respete rutas con espacios, las líneas usan comillas dobles consecutivas, por ejemplo:
+   - API: `cmd /k ""%VENV%\python.exe" ... >> "%LOG_DIR%\backend.log" 2>&1"`
+   - Frontend: `cmd /k "pushd ""%ROOT%frontend"" && npm run dev >> "%LOG_DIR%\frontend.log" 2>&1"`
+   Quitar alguna de esas comillas provoca errores como “Acceso denegado” o que el comando se ejecute en el directorio equivocado. Mantené el patrón intacto y ejecutá el script desde la raíz del proyecto.
 
 Orden de ejecución recomendado:
 

--- a/start.bat
+++ b/start.bat
@@ -51,10 +51,10 @@ if errorlevel 1 (
 )
 
 call :log "[INFO] Iniciando backend..."
-start "Growen API" cmd /k "\"%VENV%\python.exe\" -m uvicorn services.api:app --reload --host 127.0.0.1 --port 8000 --loop asyncio --http h11 >> \"%LOG_DIR%\backend.log\" 2>&1"
+start "Growen API" cmd /k ""%VENV%\python.exe" -m uvicorn services.api:app --reload --host 127.0.0.1 --port 8000 --loop asyncio --http h11 >> "%LOG_DIR%\backend.log" 2>&1"
 
 call :log "[INFO] Iniciando frontend..."
-start "Growen Frontend" cmd /k "pushd \"%ROOT%frontend\" && npm run dev >> \"%LOG_DIR%\frontend.log\" 2>&1"
+start "Growen Frontend" cmd /k "pushd ""%ROOT%frontend"" && npm run dev >> "%LOG_DIR%\frontend.log" 2>&1"
 
 endlocal
 exit /b 0


### PR DESCRIPTION
## Resumen
- Ajustar `start.bat` para que las líneas `start` escapen correctamente las rutas con espacios al iniciar backend y frontend.
- Documentar en `README.md` el patrón de comillas necesario y los riesgos de modificarlo.

## Pruebas
- `pytest -q`
- `npm test` (falla: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68ac755a77f48330a2757c90512d2aef