### PR TITLE
fix: login centrado y migración identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,6 @@
 - deps: incluir `aiosqlite` para motor SQLite asíncrono
 - dev: en ausencia de sesión y con `ENV=dev` se asume rol `admin` para facilitar pruebas
 - fix: corregir comillas en `scripts/start.bat` y `start.bat` para rutas con espacios
+- fix: soporte de `psycopg` asíncrono en Windows usando `WindowsSelectorEventLoopPolicy`
+- fix: migración idempotente que agrega `users.identifier` si falta y actualiza el modelo
+- fix: formulario de login centrado y autenticación/guest integrados con `AuthContext`

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ La API implementa sesiones mediante la cookie `growen_session` y un token CSRF a
 
 Si no hay cookie de sesión y el entorno es `dev`, se asume rol `admin` por defecto para agilizar pruebas; en otros entornos el rol por omisión es `guest`.
 
-El login acepta **identificador** o email junto con la contraseña. Al ejecutar las migraciones se crea, si no existe, un usuario administrador usando `ADMIN_USER` y `ADMIN_PASS` definidos en `.env` (ver `.env.example`). En producción el servidor se niega a iniciar si `ADMIN_PASS` queda en el placeholder `REEMPLAZAR_ADMIN_PASS`.
+El login acepta **identificador** o email junto con la contraseña. Una migración idempotente agrega la columna `identifier` si falta y la rellena a partir del correo; esto permite que bases antiguas sigan funcionando. Al ejecutar las migraciones se crea, si no existe, un usuario administrador usando `ADMIN_USER` y `ADMIN_PASS` definidos en `.env` (ver `.env.example`). En producción el servidor se niega a iniciar si `ADMIN_PASS` queda en el placeholder `REEMPLAZAR_ADMIN_PASS`.
 
 ### Endpoints principales
 

--- a/db/migrations/versions/20250825_add_identifier_to_users.py
+++ b/db/migrations/versions/20250825_add_identifier_to_users.py
@@ -1,0 +1,51 @@
+"""add identifier to users if missing (idempotent)"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# Reemplaza por un ID único si tu convención lo requiere
+revision = "20250825_add_identifier_to_users"
+down_revision = "20241105_auth_roles_sessions"
+branch_labels = None
+depends_on = None
+
+def _col_exists(conn, table, column):
+    q = sa.text("""
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = :t AND column_name = :c
+          AND table_schema = current_schema()
+        LIMIT 1
+    """)
+    return conn.execute(q, {"t": table, "c": column}).scalar() is not None
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Agregar columna si no existe
+    if not _col_exists(conn, "users", "identifier"):
+        op.add_column(
+            "users",
+            sa.Column("identifier", sa.String(length=64), nullable=True)
+        )
+        # Poblar a partir del email (parte antes de @) si hay email
+        conn.execute(sa.text("""
+            UPDATE users
+            SET identifier = COALESCE(identifier,
+                                      NULLIF(split_part(email, '@', 1), ''))
+            WHERE identifier IS NULL
+        """))
+        # Índice único si no existe
+        idx_name = "uq_users_identifier"
+        op.create_unique_constraint(idx_name, "users", ["identifier"])
+
+def downgrade():
+    # Downgrade seguro: solo elimina si existe
+    conn = op.get_bind()
+    if _col_exists(conn, "users", "identifier"):
+        # Quitar constraint si existe
+        try:
+            op.drop_constraint("uq_users_identifier", "users", type_="unique")
+        except Exception:
+            pass
+        op.drop_column("users", "identifier")

--- a/db/models.py
+++ b/db/models.py
@@ -304,7 +304,9 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    identifier: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    identifier: Mapped[Optional[str]] = mapped_column(
+        String(64), unique=True, index=True, nullable=True
+    )
     email: Mapped[Optional[str]] = mapped_column(String(255), unique=True, nullable=True)
     name: Mapped[Optional[str]] = mapped_column(String(100))
     password_hash: Mapped[str] = mapped_column(Text, nullable=False)

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -45,13 +45,13 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, [])
 
   const login = async (identifier: string, password: string) => {
-    const resp = await http.post('/auth/login', { identifier, password })
-    setState({ user: resp.data, role: resp.data.role, isAuthenticated: true })
+    await http.post('/auth/login', { identifier, password })
+    await refreshMe()
   }
 
   const loginAsGuest = async () => {
-    const resp = await http.post('/auth/guest')
-    setState({ role: resp.data.role, isAuthenticated: true })
+    await http.post('/auth/guest')
+    await refreshMe()
   }
 
   const logout = async () => {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,25 +1,25 @@
 import { useState } from "react";
-import http from "../services/http";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthContext";
 
 export default function Login() {
   const [u, setU] = useState("");
   const [p, setP] = useState("");
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const { login, loginAsGuest } = useAuth();
+  const navigate = useNavigate();
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setErr(null);
     setLoading(true);
     try {
-      await http.post("/auth/login", { identifier: u, password: p });
-      window.location.href = "/";
+      await login(u, p);
+      navigate("/");
     } catch (e: any) {
-      const msg =
-        e?.response?.data?.detail ||
-        e?.response?.data?.message ||
-        "Error al iniciar sesión";
-      setErr(msg);
+      const status = e?.response?.status;
+      setErr(status === 401 ? "Usuario o contraseña inválidos" : "Error del servidor");
     } finally {
       setLoading(false);
     }
@@ -29,21 +29,26 @@ export default function Login() {
     setErr(null);
     setLoading(true);
     try {
-      await http.post("/auth/guest");
-      window.location.href = "/";
+      await loginAsGuest();
+      navigate("/");
     } catch (e: any) {
-      const msg =
-        e?.response?.data?.detail ||
-        e?.response?.data?.message ||
-        "No se pudo ingresar como invitado";
-      setErr(msg);
+      setErr("Error del servidor");
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="min-h-screen bg-[#0f1115] text-white flex items-center justify-center">
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg, #0f1115)",
+        color: "#fff",
+      }}
+    >
       <div className="w-full max-w-sm rounded-2xl p-6 bg-[#1a1d24] shadow-lg border border-[#2a2f3a]">
         <h1 className="text-xl font-semibold mb-4 text-center">Growen</h1>
 

--- a/services/api.py
+++ b/services/api.py
@@ -1,13 +1,13 @@
 """Aplicación FastAPI principal del agente."""
 
-# --- Windows psycopg async fix: usar SelectorEventLoop ---
+# --- Windows psycopg async fix (no-op en otros SO) ---
 import sys, asyncio
 if sys.platform.startswith("win"):
     try:
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     except Exception:
         pass
-# --- fin fix ---
+# --- end fix ---
 
 import logging
 import os


### PR DESCRIPTION
## Resumen
- migración idempotente para `users.identifier`
- columna `identifier` opcional e indexada en el modelo
- login centrado y con AuthContext + invitados
- documentación actualizada y fix Windows event loop

## Pruebas
- `pip install -r requirements.txt`
- `DB_URL=postgresql+psycopg://postgres:postgres@localhost:5432/postgres alembic upgrade head` *(falla: connection refused)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac7b673af48330a0c9316baf4be202