### PR TITLE
docs: lineamientos para agentes y encabezado NG-HEADER

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,101 @@
+<!-- NG-HEADER: Nombre de archivo: AGENTS.md -->
+<!-- NG-HEADER: Ubicación: AGENTS.md -->
+<!-- NG-HEADER: Descripción: Lineamientos para agentes de desarrollo -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+
+# Lineamientos para agentes de desarrollo
+
+Este documento orienta a herramientas de asistencia de código (Copilot, Codex, Gemini, etc.) sobre cómo interactuar con este repositorio. No aplica a agentes internos de la aplicación.
+
+## Estructura de prompt obligatoria
+1. **Contexto**
+2. **Observaciones**
+3. **Errores y/u outputs**
+4. **Objetivo**
+5. **Propuesta de código o pasos**
+6. **Criterios de aceptación** (siempre exigir "documentar los cambios y actualizar si algo está desactualizado")
+
+## Estándares de entrega
+- Código listo para revisión, con pruebas cuando apliquen.
+- Mensajes de commit claros y en español.
+- Documentar cambios de esquema o infraestructura.
+- No introducir dependencias sin documentarlas y agregarlas a los requirements/README.
+
+## Encabezado obligatorio (NG-HEADER)
+Agregar al inicio de cada archivo de código y documentación `.md` (excepto `README.md`). Excepciones: `*.json`, `destinatarios.json`, binarios, imágenes, PDFs y otros archivos de datos.
+
+Formato por lenguaje:
+
+### Python
+```py
+#!/usr/bin/env python
+# NG-HEADER: Nombre de archivo: <basename>
+# NG-HEADER: Ubicación: <ruta/desde/la/raiz>
+# NG-HEADER: Descripción: <breve descripción>
+# NG-HEADER: Lineamientos: Ver AGENTS.md
+```
+
+### TypeScript/JavaScript
+```ts
+// NG-HEADER: Nombre de archivo: <basename>
+// NG-HEADER: Ubicación: <ruta/desde/la/raiz>
+// NG-HEADER: Descripción: <breve descripción>
+// NG-HEADER: Lineamientos: Ver AGENTS.md
+```
+
+### Bash
+```bash
+#!/usr/bin/env bash
+# NG-HEADER: Nombre de archivo: <basename>
+# NG-HEADER: Ubicación: <ruta/desde/la/raiz>
+# NG-HEADER: Descripción: <breve descripción>
+# NG-HEADER: Lineamientos: Ver AGENTS.md
+```
+
+### YAML / Dockerfile
+```yaml
+# NG-HEADER: Nombre de archivo: <basename>
+# NG-HEADER: Ubicación: <ruta/desde/la/raiz>
+# NG-HEADER: Descripción: <breve descripción>
+# NG-HEADER: Lineamientos: Ver AGENTS.md
+```
+```dockerfile
+# NG-HEADER: Nombre de archivo: <basename>
+# NG-HEADER: Ubicación: <ruta/desde/la/raiz>
+# NG-HEADER: Descripción: <breve descripción>
+# NG-HEADER: Lineamientos: Ver AGENTS.md
+```
+
+### HTML / CSS
+```html
+<!-- NG-HEADER: Nombre de archivo: <basename> -->
+<!-- NG-HEADER: Ubicación: <ruta/desde/la/raiz> -->
+<!-- NG-HEADER: Descripción: <breve descripción> -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+```
+```css
+/* NG-HEADER: Nombre de archivo: <basename> */
+/* NG-HEADER: Ubicación: <ruta/desde/la/raiz> */
+/* NG-HEADER: Descripción: <breve descripción> */
+/* NG-HEADER: Lineamientos: Ver AGENTS.md */
+```
+
+### Markdown de documentación
+```md
+<!-- NG-HEADER: Nombre de archivo: <basename> -->
+<!-- NG-HEADER: Ubicación: <ruta/desde/la/raiz> -->
+<!-- NG-HEADER: Descripción: <breve descripción> -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+```
+
+## Buenas prácticas para agentes
+- Confirmar impacto de cambios (migraciones, variables de entorno, dependencias nativas).
+- Dejar notas de migración cuando corresponda.
+- Adjuntar ejemplos mínimos de uso y pruebas cuando sea razonable.
+
+## Checklist para cada PR generado por un agente
+- [ ] Se agregó/actualizó encabezado NG-HEADER cuando corresponde.
+- [ ] Se actualizaron docs afectadas.
+- [ ] Se listaron dependencias nuevas y prerequisitos.
+- [ ] Se agregaron o actualizaron tests si aplica.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: CHANGELOG.md -->
+<!-- NG-HEADER: Ubicación: CHANGELOG.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 # Changelog
 
 ## [Unreleased]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+<!-- NG-HEADER: Nombre de archivo: CONTRIBUTING.md -->
+<!-- NG-HEADER: Ubicación: CONTRIBUTING.md -->
+<!-- NG-HEADER: Descripción: Guía para contribuciones -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+
+# Guía de contribuciones
+
+## Estilo de código
+- Seguir PEP8 para Python y las guías estándar de cada lenguaje.
+- Incluir siempre el encabezado `NG-HEADER` al crear nuevos archivos.
+
+## Testing
+- Ejecutar `pytest` antes de enviar un PR.
+- Incluir tests para nuevas funcionalidades cuando sea posible.
+
+## Commits
+- Mensajes en español y en modo imperativo.
+- Un commit por funcionalidad o corrección clara.
+
+## Prompts a agentes
+- Estructurar solicitudes según `AGENTS.md`.
+- Asegurar que la documentación se mantenga actualizada.
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Agente para gestión de catálogo y stock de Nice Grow con interfaz de chat web 
 - Opcional (dev/pruebas): SQLite 3 con `aiosqlite` (ya incluido en dependencias)
 - Opcional: Docker y Docker Compose
 - El backend usa httpx para llamadas a proveedores (Ollama / APIs); ya viene incluido.
+- OCR: `ocrmypdf` (requiere Tesseract, Ghostscript y Poppler). TODO: agregar "doctor" para validar instalación.
 
 ## Instalación local
 
@@ -713,3 +714,14 @@ Contribuciones y feedback son bienvenidos.
 
 - Resumen en `AuditLog(action='purchase_import')` y eventos en `ImportLog` por etapa.
 - UI: botón "Ver logs" abre un drawer con timeline, copiar `correlation_id` y descargar JSON (`GET /purchases/{id}/logs?format=json`).
+
+## Documentación adicional
+
+- [Importación de PDF](docs/IMPORT_PDF.md)
+- [Crawler de imágenes](docs/IMAGES.md)
+- [Seguridad](docs/SECURITY.md)
+
+## Lineamientos de agentes
+
+Consulta [AGENTS.md](AGENTS.md) para la estructura de prompts, el uso del encabezado NG-HEADER y el checklist de PRs.
+

--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: adapters/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Adapters para servicios externos."""

--- a/adapters/tiendanube/__init__.py
+++ b/adapters/tiendanube/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: adapters/tiendanube/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Cliente stub para Tiendanube."""

--- a/adapters/tiendanube/client.py
+++ b/adapters/tiendanube/client.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: client.py
+# NG-HEADER: Ubicación: adapters/tiendanube/client.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Cliente simulado de Tiendanube para pruebas."""
 from typing import Any, Dict, List
 

--- a/adapters/tiendanube/sync.py
+++ b/adapters/tiendanube/sync.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: sync.py
+# NG-HEADER: Ubicación: adapters/tiendanube/sync.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Sincronización simulada con Tiendanube."""
 from __future__ import annotations
 

--- a/adapters/tiendanube/webhooks.py
+++ b/adapters/tiendanube/webhooks.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: webhooks.py
+# NG-HEADER: Ubicación: adapters/tiendanube/webhooks.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Webhook de ejemplo para Tiendanube."""
 from fastapi import APIRouter, Request
 

--- a/agent_core/__init__.py
+++ b/agent_core/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: agent_core/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Núcleo del agente Growen."""

--- a/agent_core/bus.py
+++ b/agent_core/bus.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: bus.py
+# NG-HEADER: Ubicación: agent_core/bus.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Bus de eventos en memoria."""
 from collections import defaultdict
 from typing import Any, Callable, DefaultDict, List

--- a/agent_core/config.py
+++ b/agent_core/config.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: config.py
+# NG-HEADER: Ubicación: agent_core/config.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Configuración central del agente."""
 
 from __future__ import annotations

--- a/agent_core/nlu.py
+++ b/agent_core/nlu.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: nlu.py
+# NG-HEADER: Ubicación: agent_core/nlu.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Utilidades de NLU básicas."""
 from __future__ import annotations
 

--- a/agent_core/rules_engine.py
+++ b/agent_core/rules_engine.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: rules_engine.py
+# NG-HEADER: Ubicación: agent_core/rules_engine.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Motor de reglas simple para evaluar condiciones del agente."""
 from typing import Any, Callable
 

--- a/agent_core/scheduler.py
+++ b/agent_core/scheduler.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: scheduler.py
+# NG-HEADER: Ubicación: agent_core/scheduler.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Planificador mínimo basado en funciones asíncronas."""
 from __future__ import annotations
 

--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: ai/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Módulo de inteligencia artificial híbrida."""

--- a/ai/persona.py
+++ b/ai/persona.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: persona.py
+# NG-HEADER: Ubicación: ai/persona.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Global system prompt persona for the assistant (Argentine Spanish + light sarcasm).
 
 Safety baseline is always respected: never insult or target individuals or groups,

--- a/ai/policy.py
+++ b/ai/policy.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: policy.py
+# NG-HEADER: Ubicación: ai/policy.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Política de selección de proveedores IA."""
 from __future__ import annotations
 

--- a/ai/provider_base.py
+++ b/ai/provider_base.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: provider_base.py
+# NG-HEADER: Ubicación: ai/provider_base.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Interfaz común para proveedores LLM."""
 from __future__ import annotations
 

--- a/ai/providers/__init__.py
+++ b/ai/providers/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: ai/providers/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Implementaciones concretas de proveedores de IA."""

--- a/ai/providers/ollama_provider.py
+++ b/ai/providers/ollama_provider.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: ollama_provider.py
+# NG-HEADER: Ubicación: ai/providers/ollama_provider.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Proveedor local Ollama."""
 from __future__ import annotations
 

--- a/ai/providers/openai_provider.py
+++ b/ai/providers/openai_provider.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: openai_provider.py
+# NG-HEADER: Ubicación: ai/providers/openai_provider.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Proveedor remoto OpenAI."""
 from __future__ import annotations
 

--- a/ai/router.py
+++ b/ai/router.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: router.py
+# NG-HEADER: Ubicación: ai/router.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Fachada para enrutar peticiones de IA."""
 
 from __future__ import annotations

--- a/ai/types.py
+++ b/ai/types.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: types.py
+# NG-HEADER: Ubicación: ai/types.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Tipos y constantes relacionados con tareas de IA."""
 from enum import Enum
 

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: cli/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """CLI del proyecto."""

--- a/cli/ng.py
+++ b/cli/ng.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: ng.py
+# NG-HEADER: Ubicación: cli/ng.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """CLI principal de Growen usando Typer."""
 from __future__ import annotations
 

--- a/config/suppliers/default.yml
+++ b/config/suppliers/default.yml
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: default.yml
+# NG-HEADER: Ubicación: config/suppliers/default.yml
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 supplier_name: "Generico"
 file_type: "xlsx"
 encoding: "utf-8"

--- a/config/suppliers/santa-planta.yml
+++ b/config/suppliers/santa-planta.yml
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: santa-planta.yml
+# NG-HEADER: Ubicación: config/suppliers/santa-planta.yml
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 supplier_name: "Santa Planta"
 slug: "santa-planta"
 # El archivo original es Excel (.xlsx)

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,2 +1,6 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: db/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Inicialización del paquete de base de datos."""
 from .base import Base

--- a/db/base.py
+++ b/db/base.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: base.py
+# NG-HEADER: Ubicación: db/base.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Declarative base para los modelos."""
 from sqlalchemy.orm import declarative_base
 

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: env.py
+# NG-HEADER: Ubicación: db/migrations/env.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import logging
 import traceback

--- a/db/migrations/util.py
+++ b/db/migrations/util.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: util.py
+# NG-HEADER: Ubicación: db/migrations/util.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import sqlalchemy as sa

--- a/db/migrations/versions/20241005_canonical_products.py
+++ b/db/migrations/versions/20241005_canonical_products.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20241005_canonical_products.py
+# NG-HEADER: Ubicación: db/migrations/versions/20241005_canonical_products.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """add canonical products and equivalences"""
 
 from alembic import op

--- a/db/migrations/versions/20241010_add_stock_column.py
+++ b/db/migrations/versions/20241010_add_stock_column.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20241010_add_stock_column.py
+# NG-HEADER: Ubicación: db/migrations/versions/20241010_add_stock_column.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from alembic import op
 import sqlalchemy as sa
 

--- a/db/migrations/versions/20241103_imports_tables.py
+++ b/db/migrations/versions/20241103_imports_tables.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20241103_imports_tables.py
+# NG-HEADER: Ubicación: db/migrations/versions/20241103_imports_tables.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """create import tables and price history"""
 
 from alembic import op

--- a/db/migrations/versions/20241105_auth_roles_sessions.py
+++ b/db/migrations/versions/20241105_auth_roles_sessions.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20241105_auth_roles_sessions.py
+# NG-HEADER: Ubicación: db/migrations/versions/20241105_auth_roles_sessions.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import text

--- a/db/migrations/versions/20250113_import_job_rows_status_idx.py
+++ b/db/migrations/versions/20250113_import_job_rows_status_idx.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250113_import_job_rows_status_idx.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250113_import_job_rows_status_idx.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from alembic import op
 import sqlalchemy as sa
 

--- a/db/migrations/versions/20250114_supplier_price_history_idx.py
+++ b/db/migrations/versions/20250114_supplier_price_history_idx.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250114_supplier_price_history_idx.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250114_supplier_price_history_idx.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from alembic import op
 import sqlalchemy as sa
 

--- a/db/migrations/versions/20250120_add_summary_json_to_import_jobs.py
+++ b/db/migrations/versions/20250120_add_summary_json_to_import_jobs.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250120_add_summary_json_to_import_jobs.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250120_add_summary_json_to_import_jobs.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """add summary_json column to import_jobs (idempotent)
 
 Revision ID: 20250120_add_summary_json_to_import_jobs

--- a/db/migrations/versions/20250825_add_identifier_to_users.py
+++ b/db/migrations/versions/20250825_add_identifier_to_users.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250825_add_identifier_to_users.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250825_add_identifier_to_users.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """add identifier to users if missing (idempotent)"""
 
 from alembic import op

--- a/db/migrations/versions/20250825_canonical_ng_sku_nullable.py
+++ b/db/migrations/versions/20250825_canonical_ng_sku_nullable.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250825_canonical_ng_sku_nullable.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250825_canonical_ng_sku_nullable.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """make canonical_products.ng_sku nullable to allow post-insert generation
 
 Revision ID: 20250825_canonical_ng_sku_nullable

--- a/db/migrations/versions/20250825_fix_identifier_users_force.py
+++ b/db/migrations/versions/20250825_fix_identifier_users_force.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250825_fix_identifier_users_force.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250825_fix_identifier_users_force.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """force add identifier to users if still missing
 
 This migration is a safety net in case previous revisions didn't add the

--- a/db/migrations/versions/20250825_import_job_rows_add_error_json.py
+++ b/db/migrations/versions/20250825_import_job_rows_add_error_json.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250825_import_job_rows_add_error_json.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250825_import_job_rows_add_error_json.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """add missing columns to import_job_rows and ensure import_jobs.summary_json
 
 This migration is idempotent: it only adds columns if they don't exist.

--- a/db/migrations/versions/20250825_merge_heads.py
+++ b/db/migrations/versions/20250825_merge_heads.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250825_merge_heads.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250825_merge_heads.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """merge heads: supplier_price_history_idx + add_identifier_to_users
 
 Revision ID: 20250825_merge_heads

--- a/db/migrations/versions/20250829_products_prefs_and_price_history.py
+++ b/db/migrations/versions/20250829_products_prefs_and_price_history.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250829_products_prefs_and_price_history.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250829_products_prefs_and_price_history.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """user prefs, price history, audit, canonical sale_price
 
 Revision ID: 20250829_products_prefs_and_price_history

--- a/db/migrations/versions/20250831_images_extend_metadata.py
+++ b/db/migrations/versions/20250831_images_extend_metadata.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250831_images_extend_metadata.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250831_images_extend_metadata.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """extend images with metadata and path
 
 Revision ID: 20250831_images_extend_metadata

--- a/db/migrations/versions/20250831_images_pipeline_tables.py
+++ b/db/migrations/versions/20250831_images_pipeline_tables.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250831_images_pipeline_tables.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250831_images_pipeline_tables.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """images pipeline tables and flags
 
 Revision ID: 20250831_images_pipeline_tables

--- a/db/migrations/versions/20250831_purchases_module.py
+++ b/db/migrations/versions/20250831_purchases_module.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250831_purchases_module.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250831_purchases_module.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """purchases module tables
 
 Revision ID: 20250831_purchases_module

--- a/db/migrations/versions/20250901_import_logs.py
+++ b/db/migrations/versions/20250901_import_logs.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250901_import_logs.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250901_import_logs.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """import logs table
 
 Revision ID: 20250901_import_logs

--- a/db/migrations/versions/20250901_merge_images_and_import_logs.py
+++ b/db/migrations/versions/20250901_merge_images_and_import_logs.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 20250901_merge_images_and_import_logs.py
+# NG-HEADER: Ubicación: db/migrations/versions/20250901_merge_images_and_import_logs.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """merge heads: images pipeline + import logs
 
 Revision ID: 20250901_merge_images_and_import_logs

--- a/db/migrations/versions/6f8e298d069b_init_schema.py
+++ b/db/migrations/versions/6f8e298d069b_init_schema.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: 6f8e298d069b_init_schema.py
+# NG-HEADER: Ubicación: db/migrations/versions/6f8e298d069b_init_schema.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """init schema
 
 Revision ID: 6f8e298d069b

--- a/db/models.py
+++ b/db/models.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: models.py
+# NG-HEADER: Ubicación: db/models.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Modelos principales de la base de datos."""
 from __future__ import annotations
 

--- a/db/session.py
+++ b/db/session.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: session.py
+# NG-HEADER: Ubicación: db/session.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Sesión asíncrona para SQLAlchemy."""
 import asyncio
 import os

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: docker-compose.yml
+# NG-HEADER: Ubicación: docker-compose.yml
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 version: '3.9'
 services:
   db:

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -1,0 +1,19 @@
+<!-- NG-HEADER: Nombre de archivo: IMAGES.md -->
+<!-- NG-HEADER: Ubicación: docs/IMAGES.md -->
+<!-- NG-HEADER: Descripción: Crawler y gestión de imágenes -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+
+# Gestión de imágenes
+
+El crawler puede operar en dos modos:
+- **Stock**: descarga imágenes desde fuentes de stock aprobadas.
+- **Base completa**: recorre toda la base de datos para identificar imágenes faltantes.
+
+## Flujo de aprobación
+1. Las imágenes descargadas se almacenan en un área temporal.
+2. Un revisor aprueba o descarta cada imagen.
+3. Las aprobadas pueden pasar por procesos de `watermark` o `rembg` según configuración.
+
+## Logs y estados
+Cada ejecución registra acciones y estados de las imágenes para auditoría.
+

--- a/docs/IMAGES_STEP2.md
+++ b/docs/IMAGES_STEP2.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: IMAGES_STEP2.md -->
+<!-- NG-HEADER: Ubicación: docs/IMAGES_STEP2.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 Images pipeline – Step 2
 
 Env

--- a/docs/IMPORT_PDF.md
+++ b/docs/IMPORT_PDF.md
@@ -1,0 +1,27 @@
+<!-- NG-HEADER: Nombre de archivo: IMPORT_PDF.md -->
+<!-- NG-HEADER: Ubicación: docs/IMPORT_PDF.md -->
+<!-- NG-HEADER: Descripción: Flujo de importación de PDF con OCR -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+
+# Importación de PDF
+
+El proceso de importación de PDF sigue el siguiente pipeline:
+1. `pdfplumber` extrae el texto cuando es posible.
+2. `Camelot` procesa tablas embebidas.
+3. Si el PDF no contiene texto o se fuerza el proceso, se ejecuta OCR con `ocrmypdf`.
+
+## Flags relevantes
+- `debug`: genera información adicional para diagnósticos.
+- `force_ocr`: fuerza el uso de OCR incluso si el PDF tiene texto.
+
+## Política de borrador vacío
+Si el OCR no logra extraer contenido útil, se genera un borrador vacío para revisión manual.
+
+## Respuesta
+Toda respuesta incluye un `correlation_id` para trazabilidad.
+
+## Tips de diagnóstico
+- Revisar logs generados en modo `debug`.
+- Verificar dependencias externas: Tesseract, Ghostscript y Poppler.
+- Utilizar PDFs de ejemplo para pruebas controladas.
+

--- a/docs/JOBS_TNUBE.md
+++ b/docs/JOBS_TNUBE.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: JOBS_TNUBE.md -->
+<!-- NG-HEADER: Ubicación: docs/JOBS_TNUBE.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 Automatización de imágenes (Paso 2)
 ===================================
 

--- a/docs/MEDIA.md
+++ b/docs/MEDIA.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: MEDIA.md -->
+<!-- NG-HEADER: Ubicación: docs/MEDIA.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 Media y galería de productos
 ============================
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,19 @@
+<!-- NG-HEADER: Nombre de archivo: SECURITY.md -->
+<!-- NG-HEADER: Ubicación: docs/SECURITY.md -->
+<!-- NG-HEADER: Descripción: Política de seguridad del proyecto -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
+
+# Seguridad
+
+## Manejo de secretos
+- Nunca versionar archivos `.env` ni credenciales.
+- Utilizar gestores de secretos cuando sea posible.
+
+## Política de scraping
+- Solo se permiten fuentes en la whitelist del proyecto.
+- Respetar términos de uso y legislaciones vigentes.
+
+## Permisos por rol
+- Asignar el mínimo de permisos necesarios a cada rol.
+- Consultar documentación funcional para detalles específicos.
+

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: dependencies.md -->
+<!-- NG-HEADER: Ubicación: docs/dependencies.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 Dependencies and Setup
 ======================
 

--- a/docs/roles-endpoints.md
+++ b/docs/roles-endpoints.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: roles-endpoints.md -->
+<!-- NG-HEADER: Ubicación: docs/roles-endpoints.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 # Roles por endpoint
 
 Este documento enumera cada endpoint de la API con el método HTTP y los roles requeridos.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: index.html -->
+<!-- NG-HEADER: Ubicación: frontend/index.html -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 <!DOCTYPE html>
 <html lang="es" data-theme="dark">
   <head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: App.tsx
+// NG-HEADER: Ubicación: frontend/src/App.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "./auth/AuthContext";
 import ProtectedRoute from "./auth/ProtectedRoute";

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: AuthContext.tsx
+// NG-HEADER: Ubicación: frontend/src/auth/AuthContext.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { createContext, useContext, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import http from '../services/http'

--- a/frontend/src/auth/ProtectedRoute.tsx
+++ b/frontend/src/auth/ProtectedRoute.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ProtectedRoute.tsx
+// NG-HEADER: Ubicación: frontend/src/auth/ProtectedRoute.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { Navigate } from 'react-router-dom'
 import { Role, useAuth } from './AuthContext'
 

--- a/frontend/src/components/AppToolbar.tsx
+++ b/frontend/src/components/AppToolbar.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: AppToolbar.tsx
+// NG-HEADER: Ubicación: frontend/src/components/AppToolbar.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useAuth } from '../auth/AuthContext'
 import { useNavigate } from 'react-router-dom'
 import { PATHS } from '../routes/paths'

--- a/frontend/src/components/BulkSalePriceModal.tsx
+++ b/frontend/src/components/BulkSalePriceModal.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: BulkSalePriceModal.tsx
+// NG-HEADER: Ubicación: frontend/src/components/BulkSalePriceModal.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useMemo, useState } from 'react'
 import { BulkMode, bulkUpdateSalePrice } from '../services/productsEx'
 import { showToast } from './Toast'

--- a/frontend/src/components/CanonicalForm.tsx
+++ b/frontend/src/components/CanonicalForm.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: CanonicalForm.tsx
+// NG-HEADER: Ubicación: frontend/src/components/CanonicalForm.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import {
   createCanonicalProduct,

--- a/frontend/src/components/CanonicalOffers.tsx
+++ b/frontend/src/components/CanonicalOffers.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: CanonicalOffers.tsx
+// NG-HEADER: Ubicación: frontend/src/components/CanonicalOffers.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 // File consolidated below; removed duplicate earlier implementation
 import { useEffect, useState } from 'react'
 import { getProductOfferings, OfferingRow, updateSupplierBuyPrice } from '../services/productsEx'

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ChatWindow.tsx
+// NG-HEADER: Ubicación: frontend/src/components/ChatWindow.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useRef, useState } from 'react'
 import { createWS, WSMessage } from '../lib/ws'
 import { chatHttp } from '../lib/http'

--- a/frontend/src/components/CreateSupplierModal.tsx
+++ b/frontend/src/components/CreateSupplierModal.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: CreateSupplierModal.tsx
+// NG-HEADER: Ubicación: frontend/src/components/CreateSupplierModal.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { createSupplier, Supplier } from '../services/suppliers'
 import { showToast } from './Toast'

--- a/frontend/src/components/DragDropZone.tsx
+++ b/frontend/src/components/DragDropZone.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: DragDropZone.tsx
+// NG-HEADER: Ubicación: frontend/src/components/DragDropZone.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useState } from 'react'
 
 type Props = { onFileDropped: (file: File) => void }

--- a/frontend/src/components/EquivalenceLinker.tsx
+++ b/frontend/src/components/EquivalenceLinker.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: EquivalenceLinker.tsx
+// NG-HEADER: Ubicación: frontend/src/components/EquivalenceLinker.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useState } from 'react'
 import { upsertEquivalence } from '../services/equivalences'
 

--- a/frontend/src/components/ImportViewer.tsx
+++ b/frontend/src/components/ImportViewer.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ImportViewer.tsx
+// NG-HEADER: Ubicación: frontend/src/components/ImportViewer.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { commitImport, getImportPreview } from '../services/imports'
 import CanonicalOffers from './CanonicalOffers'

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Login.tsx
+// NG-HEADER: Ubicación: frontend/src/components/Login.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
 

--- a/frontend/src/components/PdfImportModal.tsx
+++ b/frontend/src/components/PdfImportModal.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: PdfImportModal.tsx
+// NG-HEADER: Ubicación: frontend/src/components/PdfImportModal.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { listSuppliers, Supplier } from '../services/suppliers'
 import { importSantaPlanta } from '../services/purchases'

--- a/frontend/src/components/PriceHistoryModal.tsx
+++ b/frontend/src/components/PriceHistoryModal.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: PriceHistoryModal.tsx
+// NG-HEADER: Ubicación: frontend/src/components/PriceHistoryModal.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { getPriceHistory, PriceHistoryItem } from '../services/prices'
 

--- a/frontend/src/components/ProductsDrawer.tsx
+++ b/frontend/src/components/ProductsDrawer.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ProductsDrawer.tsx
+// NG-HEADER: Ubicación: frontend/src/components/ProductsDrawer.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 // File consolidated below; removed duplicate earlier implementation
 import { useEffect, useMemo, useState } from 'react'
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window'

--- a/frontend/src/components/SuppliersModal.tsx
+++ b/frontend/src/components/SuppliersModal.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: SuppliersModal.tsx
+// NG-HEADER: Ubicación: frontend/src/components/SuppliersModal.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { listSuppliers, Supplier } from '../services/suppliers'
 import CreateSupplierModal from './CreateSupplierModal'

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Toast.tsx
+// NG-HEADER: Ubicación: frontend/src/components/Toast.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 
 type Toast = { type: 'success' | 'error'; text: string }

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: UploadModal.tsx
+// NG-HEADER: Ubicación: frontend/src/components/UploadModal.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import {
   uploadPriceList,

--- a/frontend/src/lib/commands.ts
+++ b/frontend/src/lib/commands.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: commands.ts
+// NG-HEADER: Ubicación: frontend/src/lib/commands.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export const examples = [
   '/help',
   '/sync pull --dry-run',

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: format.ts
+// NG-HEADER: Ubicación: frontend/src/lib/format.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export function formatARS(n: number | null | undefined): string {
   if (n == null) return ''
   try {

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: http.ts
+// NG-HEADER: Ubicación: frontend/src/lib/http.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export type ChatResponse = { role: string; text: string }
 
 export async function chatHttp(text: string): Promise<ChatResponse> {

--- a/frontend/src/lib/useTablePrefs.ts
+++ b/frontend/src/lib/useTablePrefs.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: useTablePrefs.ts
+// NG-HEADER: Ubicación: frontend/src/lib/useTablePrefs.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getProductsTablePrefs, putProductsTablePrefs, ProductsTablePrefs } from '../services/productsEx'
 

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ws.ts
+// NG-HEADER: Ubicación: frontend/src/lib/ws.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export type WSMessage = { role: string; text: string }
 
 export function createWS(onMessage: (m: WSMessage) => void) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: main.tsx
+// NG-HEADER: Ubicación: frontend/src/main.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: AdminPanel.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/AdminPanel.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import http from '../services/http'

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Dashboard.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/Dashboard.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import AppToolbar from '../components/AppToolbar'
 import { useNavigate } from 'react-router-dom'
 import { PATHS } from '../routes/paths'

--- a/frontend/src/pages/ImagesAdminPanel.tsx
+++ b/frontend/src/pages/ImagesAdminPanel.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ImagesAdminPanel.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/ImagesAdminPanel.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import http from '../services/http'
 import { Link } from 'react-router-dom'

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Login.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/Login.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: ProductDetail.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/ProductDetail.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import http from '../services/http'

--- a/frontend/src/pages/Productos.tsx
+++ b/frontend/src/pages/Productos.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Productos.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/Productos.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import AppToolbar from '../components/AppToolbar'
 import ProductsDrawer from '../components/ProductsDrawer'
 import ToastContainer from '../components/Toast'

--- a/frontend/src/pages/PurchaseDetail.tsx
+++ b/frontend/src/pages/PurchaseDetail.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: PurchaseDetail.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/PurchaseDetail.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams, Link, useSearchParams } from 'react-router-dom'
 import { PATHS } from '../routes/paths'

--- a/frontend/src/pages/PurchaseNew.tsx
+++ b/frontend/src/pages/PurchaseNew.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: PurchaseNew.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/PurchaseNew.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useCallback, useEffect, useRef, useState } from 'react'
 import AppToolbar from '../components/AppToolbar'
 import http from '../services/http'

--- a/frontend/src/pages/Purchases.tsx
+++ b/frontend/src/pages/Purchases.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Purchases.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/Purchases.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import AppToolbar from '../components/AppToolbar'

--- a/frontend/src/pages/Stock.tsx
+++ b/frontend/src/pages/Stock.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Stock.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/Stock.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import { listSuppliers, Supplier } from '../services/suppliers'
 import { useNavigate } from 'react-router-dom'

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: Suppliers.tsx
+// NG-HEADER: Ubicación: frontend/src/pages/Suppliers.tsx
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { useEffect, useState } from 'react'
 import AppToolbar from '../components/AppToolbar'
 import { Supplier, listSuppliers } from '../services/suppliers'

--- a/frontend/src/routes/paths.ts
+++ b/frontend/src/routes/paths.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: paths.ts
+// NG-HEADER: Ubicación: frontend/src/routes/paths.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export const PATHS = {
   home: "/",
   products: "/productos",

--- a/frontend/src/services/canonical.ts
+++ b/frontend/src/services/canonical.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: canonical.ts
+// NG-HEADER: Ubicación: frontend/src/services/canonical.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import http from './http'
 
 export interface CanonicalOffer {

--- a/frontend/src/services/categories.ts
+++ b/frontend/src/services/categories.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: categories.ts
+// NG-HEADER: Ubicación: frontend/src/services/categories.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export interface Category { id: number; name: string }
 import { baseURL as base } from './http'
 

--- a/frontend/src/services/equivalences.ts
+++ b/frontend/src/services/equivalences.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: equivalences.ts
+// NG-HEADER: Ubicación: frontend/src/services/equivalences.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import http from './http'
 
 export interface EquivalenceRequest {

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: http.ts
+// NG-HEADER: Ubicación: frontend/src/services/http.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import axios from "axios";
 
 // Compute a single API base bound to the current page hostname to avoid

--- a/frontend/src/services/images.ts
+++ b/frontend/src/services/images.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: images.ts
+// NG-HEADER: Ubicación: frontend/src/services/images.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import http from './http'
 
 export interface ImageItem {

--- a/frontend/src/services/imports.ts
+++ b/frontend/src/services/imports.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: imports.ts
+// NG-HEADER: Ubicación: frontend/src/services/imports.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import http, { baseURL as base } from './http'
 
 export async function uploadPriceList(

--- a/frontend/src/services/prices.ts
+++ b/frontend/src/services/prices.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: prices.ts
+// NG-HEADER: Ubicación: frontend/src/services/prices.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export interface PriceHistoryParams {
   supplier_product_id?: number
   product_id?: number

--- a/frontend/src/services/products.ts
+++ b/frontend/src/services/products.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: products.ts
+// NG-HEADER: Ubicación: frontend/src/services/products.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export interface ProductSearchParams {
   q?: string
   supplier_id?: number

--- a/frontend/src/services/productsEx.ts
+++ b/frontend/src/services/productsEx.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: productsEx.ts
+// NG-HEADER: Ubicación: frontend/src/services/productsEx.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { baseURL as base } from './http'
 
 function csrfHeaders(): Record<string, string> {

--- a/frontend/src/services/purchases.ts
+++ b/frontend/src/services/purchases.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: purchases.ts
+// NG-HEADER: Ubicación: frontend/src/services/purchases.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import http from './http'
 
 export type PurchaseLine = {

--- a/frontend/src/services/suppliers.ts
+++ b/frontend/src/services/suppliers.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: suppliers.ts
+// NG-HEADER: Ubicación: frontend/src/services/suppliers.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 export interface Supplier {
   id: number
   name: string

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,3 +1,7 @@
+/* NG-HEADER: Nombre de archivo: theme.css */
+/* NG-HEADER: Ubicación: frontend/src/styles/theme.css */
+/* NG-HEADER: Descripción: Pendiente de descripción */
+/* NG-HEADER: Lineamientos: Ver AGENTS.md */
 :root {
   --bg: #0f1115;
   --panel: #151821;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
+// NG-HEADER: Nombre de archivo: vite-env.d.ts
+// NG-HEADER: Ubicación: frontend/src/vite-env.d.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 /// <reference types="vite/client" />

--- a/frontend/tools/check-deps.js
+++ b/frontend/tools/check-deps.js
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: check-deps.js
+// NG-HEADER: Ubicación: frontend/tools/check-deps.js
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 /* Simple dependency checker for Growen frontend */
 const { execSync } = require('node:child_process');
 const fs = require('node:fs');

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,7 @@
+// NG-HEADER: Nombre de archivo: vite.config.ts
+// NG-HEADER: Ubicación: frontend/vite.config.ts
+// NG-HEADER: Descripción: Pendiente de descripción
+// NG-HEADER: Lineamientos: Ver AGENTS.md
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 

--- a/infra/wait-for.sh
+++ b/infra/wait-for.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# NG-HEADER: Nombre de archivo: wait-for.sh
+# NG-HEADER: Ubicación: infra/wait-for.sh
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 set -e
 host="$1"
 shift

--- a/scripts/check_schema.py
+++ b/scripts/check_schema.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: check_schema.py
+# NG-HEADER: Ubicación: scripts/check_schema.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from sqlalchemy import create_engine, text
 from dotenv import load_dotenv

--- a/scripts/clear_logs.py
+++ b/scripts/clear_logs.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: clear_logs.py
+# NG-HEADER: Ubicación: scripts/clear_logs.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from pathlib import Path
 import sys

--- a/scripts/db_check.py
+++ b/scripts/db_check.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: db_check.py
+# NG-HEADER: Ubicación: scripts/db_check.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from agent_core.config import settings
 from sqlalchemy import create_engine, text, inspect

--- a/scripts/debug_migrations.py
+++ b/scripts/debug_migrations.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# NG-HEADER: Nombre de archivo: debug_migrations.py
+# NG-HEADER: Ubicación: scripts/debug_migrations.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Diagnóstico de migraciones de Alembic.
 
 Genera un reporte con la versión actual, los heads y el historial

--- a/scripts/generate_requirements.py
+++ b/scripts/generate_requirements.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: generate_requirements.py
+# NG-HEADER: Ubicación: scripts/generate_requirements.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import tomllib
 from pathlib import Path
 

--- a/scripts/patch_add_identifier.py
+++ b/scripts/patch_add_identifier.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: patch_add_identifier.py
+# NG-HEADER: Ubicación: scripts/patch_add_identifier.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from agent_core.config import settings
 from sqlalchemy import create_engine, text
 

--- a/scripts/patch_summary_json.py
+++ b/scripts/patch_summary_json.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: patch_summary_json.py
+# NG-HEADER: Ubicación: scripts/patch_summary_json.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from sqlalchemy import create_engine, text
 from dotenv import load_dotenv

--- a/scripts/seed_admin.py
+++ b/scripts/seed_admin.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: seed_admin.py
+# NG-HEADER: Ubicación: scripts/seed_admin.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from sqlalchemy import create_engine, text
 from passlib.hash import argon2

--- a/scripts/smoke_import_commit.py
+++ b/scripts/smoke_import_commit.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: smoke_import_commit.py
+# NG-HEADER: Ubicación: scripts/smoke_import_commit.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import json
 import os
 import sys

--- a/scripts/stamp_head_manual.py
+++ b/scripts/stamp_head_manual.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: stamp_head_manual.py
+# NG-HEADER: Ubicación: scripts/stamp_head_manual.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from sqlalchemy import create_engine, text
 from dotenv import load_dotenv

--- a/scripts/test_login_flow.py
+++ b/scripts/test_login_flow.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_login_flow.py
+# NG-HEADER: Ubicación: scripts/test_login_flow.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import requests, sys
 base = 'http://localhost:8000'
 s = requests.Session()

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Servicios expuestos por el agente."""

--- a/services/ai/__init__.py
+++ b/services/ai/__init__.py
@@ -1,0 +1,4 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/ai/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md

--- a/services/ai/provider.py
+++ b/services/ai/provider.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: provider.py
+# NG-HEADER: Ubicación: services/ai/provider.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Cliente de IA que se conecta a Ollama.
 
 La URL del servicio se lee desde la variable de entorno ``OLLAMA_URL``,

--- a/services/api.py
+++ b/services/api.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: api.py
+# NG-HEADER: Ubicación: services/api.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Aplicación FastAPI principal del agente."""
 
 # --- Windows psycopg async fix (no-op en otros SO) ---

--- a/services/auth.py
+++ b/services/auth.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: auth.py
+# NG-HEADER: Ubicación: services/auth.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Utilidades de autenticación y manejo de sesiones."""
 
 from __future__ import annotations

--- a/services/importers/santaplanta_pipeline.py
+++ b/services/importers/santaplanta_pipeline.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: santaplanta_pipeline.py
+# NG-HEADER: Ubicación: services/importers/santaplanta_pipeline.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/services/ingest/__init__.py
+++ b/services/ingest/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/ingest/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Herramientas de ingestión de catálogos de proveedores."""

--- a/services/ingest/detect.py
+++ b/services/ingest/detect.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: detect.py
+# NG-HEADER: Ubicación: services/ingest/detect.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Heurísticas básicas para detectar proveedor."""
 from __future__ import annotations
 

--- a/services/ingest/loader.py
+++ b/services/ingest/loader.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: loader.py
+# NG-HEADER: Ubicación: services/ingest/loader.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Carga archivos CSV/XLSX usando pandas."""
 from __future__ import annotations
 

--- a/services/ingest/mapping.py
+++ b/services/ingest/mapping.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: mapping.py
+# NG-HEADER: Ubicación: services/ingest/mapping.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Resuelve columnas externas a nombres internos."""
 from __future__ import annotations
 

--- a/services/ingest/normalize.py
+++ b/services/ingest/normalize.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: normalize.py
+# NG-HEADER: Ubicación: services/ingest/normalize.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Funciones de limpieza de datos."""
 from __future__ import annotations
 

--- a/services/ingest/report.py
+++ b/services/ingest/report.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: report.py
+# NG-HEADER: Ubicación: services/ingest/report.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Generación simple de reportes."""
 from __future__ import annotations
 

--- a/services/ingest/upsert.py
+++ b/services/ingest/upsert.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: upsert.py
+# NG-HEADER: Ubicación: services/ingest/upsert.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Inserta o actualiza productos y variantes."""
 from __future__ import annotations
 

--- a/services/ingest/validate.py
+++ b/services/ingest/validate.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: validate.py
+# NG-HEADER: Ubicación: services/ingest/validate.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Validaciones simples de filas."""
 from __future__ import annotations
 

--- a/services/integrations/tiendanube.py
+++ b/services/integrations/tiendanube.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: tiendanube.py
+# NG-HEADER: Ubicación: services/integrations/tiendanube.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os

--- a/services/intents/__init__.py
+++ b/services/intents/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/intents/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Manejo de intents del agente."""

--- a/services/intents/handlers.py
+++ b/services/intents/handlers.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: handlers.py
+# NG-HEADER: Ubicación: services/intents/handlers.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Handlers de intents de ejemplo."""
 
 from typing import Any, Dict, List

--- a/services/intents/router.py
+++ b/services/intents/router.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: router.py
+# NG-HEADER: Ubicación: services/intents/router.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Enrutador de intents y dispatcher de handlers."""
 
 from __future__ import annotations

--- a/services/jobs/__init__.py
+++ b/services/jobs/__init__.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/jobs/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os

--- a/services/jobs/images.py
+++ b/services/jobs/images.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: images.py
+# NG-HEADER: Ubicación: services/jobs/images.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import logging

--- a/services/jobs/manager.py
+++ b/services/jobs/manager.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: manager.py
+# NG-HEADER: Ubicación: services/jobs/manager.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Administrador muy básico de jobs."""
 from __future__ import annotations
 

--- a/services/media/__init__.py
+++ b/services/media/__init__.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/media/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Media helpers: paths, naming, and simple file ops."""
 from __future__ import annotations
 

--- a/services/media/downloader.py
+++ b/services/media/downloader.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: downloader.py
+# NG-HEADER: Ubicación: services/media/downloader.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import asyncio

--- a/services/media/orchestrator.py
+++ b/services/media/orchestrator.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: orchestrator.py
+# NG-HEADER: Ubicación: services/media/orchestrator.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 from typing import Optional

--- a/services/media/processor.py
+++ b/services/media/processor.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: processor.py
+# NG-HEADER: Ubicación: services/media/processor.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/services/media/seo.py
+++ b/services/media/seo.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: seo.py
+# NG-HEADER: Ubicación: services/media/seo.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 from typing import Optional

--- a/services/notifications/telegram.py
+++ b/services/notifications/telegram.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: telegram.py
+# NG-HEADER: Ubicación: services/notifications/telegram.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os

--- a/services/ocr/utils.py
+++ b/services/ocr/utils.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: utils.py
+# NG-HEADER: Ubicación: services/ocr/utils.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os

--- a/services/routers/__init__.py
+++ b/services/routers/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/routers/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Routers de la API."""

--- a/services/routers/actions.py
+++ b/services/routers/actions.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: actions.py
+# NG-HEADER: Ubicación: services/routers/actions.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Lista de acciones rápidas disponibles."""
 from fastapi import APIRouter
 

--- a/services/routers/auth.py
+++ b/services/routers/auth.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: auth.py
+# NG-HEADER: Ubicación: services/routers/auth.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Endpoints de autenticación y gestión de usuarios."""
 
 import secrets

--- a/services/routers/canonical_products.py
+++ b/services/routers/canonical_products.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: canonical_products.py
+# NG-HEADER: Ubicación: services/routers/canonical_products.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Endpoints para productos canónicos y equivalencias."""
 from __future__ import annotations
 

--- a/services/routers/catalog.py
+++ b/services/routers/catalog.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: catalog.py
+# NG-HEADER: Ubicación: services/routers/catalog.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Endpoints para gestionar proveedores y categorías."""
 from __future__ import annotations
 

--- a/services/routers/chat.py
+++ b/services/routers/chat.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: chat.py
+# NG-HEADER: Ubicación: services/routers/chat.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Endpoint de chat síncrono que consulta la IA."""
 
 from fastapi import APIRouter

--- a/services/routers/debug.py
+++ b/services/routers/debug.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: debug.py
+# NG-HEADER: Ubicación: services/routers/debug.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Endpoints de diagnóstico y salud."""
 
 from fastapi import APIRouter, Depends

--- a/services/routers/health.py
+++ b/services/routers/health.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: health.py
+# NG-HEADER: Ubicación: services/routers/health.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/services/routers/image_jobs.py
+++ b/services/routers/image_jobs.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: image_jobs.py
+# NG-HEADER: Ubicación: services/routers/image_jobs.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 from typing import Optional

--- a/services/routers/images.py
+++ b/services/routers/images.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: images.py
+# NG-HEADER: Ubicación: services/routers/images.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os

--- a/services/routers/imports.py
+++ b/services/routers/imports.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: imports.py
+# NG-HEADER: Ubicación: services/routers/imports.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Endpoints para importar listas de precios de proveedores."""
 
 from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Depends, Query

--- a/services/routers/media.py
+++ b/services/routers/media.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: media.py
+# NG-HEADER: Ubicación: services/routers/media.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Media endpoints: minimal upload for testing static serving.
 
 These are basic and admin-only; a fuller pipeline will replace them.

--- a/services/routers/products_ex.py
+++ b/services/routers/products_ex.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: products_ex.py
+# NG-HEADER: Ubicación: services/routers/products_ex.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 from decimal import Decimal

--- a/services/routers/purchases.py
+++ b/services/routers/purchases.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: purchases.py
+# NG-HEADER: Ubicación: services/routers/purchases.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Compras (purchases) API endpoints.
 
 Estados de compra: BORRADOR -> VALIDADA -> CONFIRMADA -> ANULADA.

--- a/services/routers/ws.py
+++ b/services/routers/ws.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: ws.py
+# NG-HEADER: Ubicación: services/routers/ws.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """WebSocket de chat que utiliza la IA de respaldo."""
 
 from datetime import datetime

--- a/services/runserver.py
+++ b/services/runserver.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: runserver.py
+# NG-HEADER: Ubicación: services/runserver.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Local development server runner.
 
 Ensures Windows uses the Selector event loop policy before Uvicorn starts,

--- a/services/scrapers/fallback.py
+++ b/services/scrapers/fallback.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: fallback.py
+# NG-HEADER: Ubicación: services/scrapers/fallback.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os

--- a/services/scrapers/santaplanta.py
+++ b/services/scrapers/santaplanta.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: santaplanta.py
+# NG-HEADER: Ubicación: services/scrapers/santaplanta.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import asyncio

--- a/services/suppliers/__init__.py
+++ b/services/suppliers/__init__.py
@@ -1,0 +1,4 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: services/suppliers/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md

--- a/services/suppliers/parsers.py
+++ b/services/suppliers/parsers.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: parsers.py
+# NG-HEADER: Ubicación: services/suppliers/parsers.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Parsers de listas de precios de proveedores.
 
 Este módulo expone un parser genérico basado en archivos Excel/CSV

--- a/services/suppliers/santaplanta_pdf.py
+++ b/services/suppliers/santaplanta_pdf.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: santaplanta_pdf.py
+# NG-HEADER: Ubicación: services/suppliers/santaplanta_pdf.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Parser de remitos Santa Planta (PDF).
 
 Heurístico y tolerante: intenta extraer número de remito, fecha y líneas con

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# NG-HEADER: Nombre de archivo: start.sh
+# NG-HEADER: Ubicación: start.sh
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 set -euo pipefail
 
 # Ir a la raíz del repo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: conftest.py
+# NG-HEADER: Ubicación: tests/conftest.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import sys
 from pathlib import Path

--- a/tests/manual/e2e-mutations.md
+++ b/tests/manual/e2e-mutations.md
@@ -1,3 +1,7 @@
+<!-- NG-HEADER: Nombre de archivo: e2e-mutations.md -->
+<!-- NG-HEADER: Ubicación: tests/manual/e2e-mutations.md -->
+<!-- NG-HEADER: Descripción: Pendiente de descripción -->
+<!-- NG-HEADER: Lineamientos: Ver AGENTS.md -->
 # Pruebas manuales E2E de mutaciones
 
 ## Crear proveedor

--- a/tests/test_ai_policy.py
+++ b/tests/test_ai_policy.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ai_policy.py
+# NG-HEADER: Ubicación: tests/test_ai_policy.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from ai.policy import choose
 from ai.types import Task
 from agent_core.config import Settings

--- a/tests/test_ai_provider.py
+++ b/tests/test_ai_provider.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ai_provider.py
+# NG-HEADER: Ubicación: tests/test_ai_provider.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import asyncio
 import json
 import logging

--- a/tests/test_ai_router.py
+++ b/tests/test_ai_router.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ai_router.py
+# NG-HEADER: Ubicación: tests/test_ai_router.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from ai.router import AIRouter
 from ai.types import Task
 from agent_core.config import Settings

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_debug_endpoints.py
+# NG-HEADER: Ubicación: tests/test_debug_endpoints.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 from fastapi.testclient import TestClient
 

--- a/tests/test_download_generic_template.py
+++ b/tests/test_download_generic_template.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_download_generic_template.py
+# NG-HEADER: Ubicación: tests/test_download_generic_template.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import asyncio
 from io import BytesIO

--- a/tests/test_images_api.py
+++ b/tests/test_images_api.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_images_api.py
+# NG-HEADER: Ubicación: tests/test_images_api.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import io
 import asyncio

--- a/tests/test_import_access.py
+++ b/tests/test_import_access.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_import_access.py
+# NG-HEADER: Ubicación: tests/test_import_access.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import asyncio
 

--- a/tests/test_ingest_dryrun.py
+++ b/tests/test_ingest_dryrun.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ingest_dryrun.py
+# NG-HEADER: Ubicación: tests/test_ingest_dryrun.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 import pytest
 from sqlalchemy import select, func

--- a/tests/test_ingest_mapping.py
+++ b/tests/test_ingest_mapping.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ingest_mapping.py
+# NG-HEADER: Ubicación: tests/test_ingest_mapping.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 import yaml
 

--- a/tests/test_ingest_normalize.py
+++ b/tests/test_ingest_normalize.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ingest_normalize.py
+# NG-HEADER: Ubicación: tests/test_ingest_normalize.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 
 from services.ingest import normalize

--- a/tests/test_ingest_upsert.py
+++ b/tests/test_ingest_upsert.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ingest_upsert.py
+# NG-HEADER: Ubicación: tests/test_ingest_upsert.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 import pytest
 from sqlalchemy import select, func

--- a/tests/test_intents_handlers.py
+++ b/tests/test_intents_handlers.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_intents_handlers.py
+# NG-HEADER: Ubicación: tests/test_intents_handlers.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Pruebas de los handlers de intents."""
 
 from __future__ import annotations

--- a/tests/test_purchases_api.py
+++ b/tests/test_purchases_api.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_purchases_api.py
+# NG-HEADER: Ubicación: tests/test_purchases_api.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import io
 import os
 from fastapi.testclient import TestClient

--- a/tests/test_santaplanta_apply.py
+++ b/tests/test_santaplanta_apply.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_santaplanta_apply.py
+# NG-HEADER: Ubicación: tests/test_santaplanta_apply.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import hashlib
 import pandas as pd
 import pytest

--- a/tests/test_santaplanta_detect.py
+++ b/tests/test_santaplanta_detect.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_santaplanta_detect.py
+# NG-HEADER: Ubicación: tests/test_santaplanta_detect.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 from services.ingest import detect
 

--- a/tests/test_santaplanta_dryrun.py
+++ b/tests/test_santaplanta_dryrun.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_santaplanta_dryrun.py
+# NG-HEADER: Ubicación: tests/test_santaplanta_dryrun.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 import pytest
 from sqlalchemy import select, func

--- a/tests/test_santaplanta_mapping.py
+++ b/tests/test_santaplanta_mapping.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_santaplanta_mapping.py
+# NG-HEADER: Ubicación: tests/test_santaplanta_mapping.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import pandas as pd
 import yaml
 from services.ingest import mapping

--- a/tests/test_suppliers_api.py
+++ b/tests/test_suppliers_api.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_suppliers_api.py
+# NG-HEADER: Ubicación: tests/test_suppliers_api.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import asyncio
 

--- a/tests/test_ws_chat.py
+++ b/tests/test_ws_chat.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ws_chat.py
+# NG-HEADER: Ubicación: tests/test_ws_chat.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import os
 import asyncio
 from datetime import datetime, timedelta

--- a/tests/test_ws_logging.py
+++ b/tests/test_ws_logging.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: test_ws_logging.py
+# NG-HEADER: Ubicación: tests/test_ws_logging.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 import logging
 
 from test_ws_chat import client

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,1 +1,5 @@
+# NG-HEADER: Nombre de archivo: __init__.py
+# NG-HEADER: Ubicación: tools/__init__.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Utilities for project maintenance (doctor, logs)."""

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: doctor.py
+# NG-HEADER: Ubicación: tools/doctor.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Project doctor: validates env, Python deps, quick syntax, and optional auto-fix.
 
 Run manually:

--- a/tools/logs.py
+++ b/tools/logs.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: logs.py
+# NG-HEADER: Ubicación: tools/logs.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 """Utilities to purge or rotate project logs.
 
 Usage:

--- a/workers/images.py
+++ b/workers/images.py
@@ -1,3 +1,7 @@
+# NG-HEADER: Nombre de archivo: images.py
+# NG-HEADER: Ubicación: workers/images.py
+# NG-HEADER: Descripción: Pendiente de descripción
+# NG-HEADER: Lineamientos: Ver AGENTS.md
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Resumen
- Agregado `AGENTS.md` con estructura de prompts, estándares de entrega y política de encabezado NG-HEADER.
- Actualizados `README.md`, `CONTRIBUTING.md` y nueva documentación `docs/IMPORT_PDF.md`, `docs/IMAGES.md`, `docs/SECURITY.md`.
- Aplicado encabezado NG-HEADER a archivos de código y documentación en todo el repositorio.

## Pruebas
- `pytest` *(falla: 8 fallos, 26 exitosos)*
- `grep -R "NG-HEADER:" -n | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_68b5f2022cf88330b81c6ee52a04eaf2